### PR TITLE
perf: re-run against cnfast 0.2.0

### DIFF
--- a/.changeset/rerun-cnfast-020.md
+++ b/.changeset/rerun-cnfast-020.md
@@ -1,0 +1,5 @@
+---
+"cn": patch
+---
+
+Faster many-argument calls: predictions are now probed in place, so a warm 4+ argument call allocates nothing (~44ns → ~32ns).

--- a/README.md
+++ b/README.md
@@ -76,31 +76,30 @@ its own warmup, and kept the best of 5 runs.
 To see the results for yourself, run `pnpm bench`. The methodology is
 in [docs/how-it-works.md](https://github.com/shadcn-ui/cn/blob/main/docs/how-it-works.md#benchmark-methodology).
 
-| scenario                                | clsx + tailwind-merge | cnfast |         cn |  faster³ |
-| --------------------------------------- | --------------------: | -----: | ---------: | -------: |
-| the call your components make most¹     |                319 ns | 33 ns² |  **10 ns** |  **30×** |
-| same classes as last render (cache hit) |                 14 ns |   8 ns |   **8 ns** | **1.8×** |
-| typical component strings, warm         |                 13 ns |   7 ns |   **6 ns** | **2.1×** |
-| thousands of recurring strings (a real repo's working set) | 2.4 µs | 727 ns | **14 ns** | **171×** |
-| cold render, many arbitrary values      |                3.4 µs | 3.5 µs | **1.2 µs** | **2.9×** |
-| cold render, SSR-style unique strings   |                2.3 µs | 703 ns | **376 ns** | **6.1×** |
-| very first call (page load)             |                3.4 ms | 3.7 ms | **0.3 ms** |  **11×** |
+Bold marks the fastest implementation on each row (both, when tied).
+
+| scenario                                                   | clsx + tailwind-merge |   cnfast² |         cn | faster³ |
+| ---------------------------------------------------------- | --------------------: | --------: | ---------: | ------: |
+| the call your components make most¹                        |                320 ns | **10 ns** |  **10 ns** |     30× |
+| same classes as last render (cache hit)                    |                 14 ns |  **7 ns** |   **7 ns** |    1.9× |
+| typical component strings, warm                            |                 13 ns |  **6 ns** |       7 ns |    1.9× |
+| thousands of recurring strings (a real repo's working set) |                2.4 µs | **13 ns** |      14 ns |    172× |
+| cold render, many arbitrary values                         |                3.4 µs |    1.9 µs | **1.1 µs** |    3.0× |
+| cold render, SSR-style unique strings                      |                2.3 µs |    555 ns | **360 ns** |    6.4× |
+| very first call (page load)                                |                3.2 ms |    4.3 ms | **0.4 ms** |      7× |
 
 ¹ `cn(base, variant, condition && extra)` with stable class strings. This is
 the shape almost every component call has. `cn` learns repeated call
 sequences, so a render loop's calls verify by identity and skip the work
 entirely. The headline rounds down.
 
-² cnfast's cache for this call only works on Chrome's engine. It detects the
-browser and turns itself off everywhere else. `cn`'s cache works in every
-browser.
+² compared to cnfast 0.2.0.
 
 ³ compared to `clsx` + `tailwind-merge`.
 
-`cn` ships the least JavaScript to parse in every setup. Parse time is the
-cost you feel on slower devices, and it is why the first call is 11× faster.
+`cn` ships the least JavaScript to parse in every setup, 26 KB minified.
 
-If you want the smallest option on both counts, run
+If you want an even smaller bundle with the same performance, see
 [`cn build`](https://github.com/shadcn-ui/cn/blob/main/docs/build-setup.md).
 
 ## Custom themes

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -5,7 +5,7 @@ the package.
 
 ## The architectural difference
 
-tailwind-merge and cnfast (same engine) ships Tailwind's conflict
+tailwind-merge and cnfast (a fork of its engine) ship Tailwind's conflict
 rules as a runtime JavaScript config object — ~380 class groups of literals,
 theme references, and validator regexes — and interprets it on every uncached
 call: split the token on `-`, walk a `Map` trie over the parts, run regex
@@ -63,7 +63,8 @@ The consequences fall out directly:
 
 1. **Speed** — no config interpretation at runtime (the cold-path numbers).
 2. **Instant init** — tailwind-merge builds its trie from the config on first
-   call (~3.4 ms); `cn` just fills typed arrays from packed strings (~0.3 ms).
+   call (~3.2 ms, cnfast ~4.3 ms); `cn` just fills typed arrays from packed
+   strings (~0.4 ms).
 3. **Project-fitted tables** — because tables are compiler output, they can be
    regenerated against a project's actual classes (`cn build`), which the
    incumbents structurally cannot do: their config object _is_ their public
@@ -103,14 +104,18 @@ pollution, GC pressure, and V8 tiering cross-contaminate implementations — we
 measured swings of 5× from ordering effects alone before isolating.
 
 Two honest caveats to the numbers: microbenchmark nanoseconds vary a few
-percent run to run (cn and cnfast trade places on the SSR workload within
-±3%), and the "cold" workloads are synthetic worst cases — real renders are
-dominated by the cache-hit rows.
+percent run to run (cn and cnfast 0.2.0 trade places on the warmest rows —
+single-site component calls, short recurring strings, large recurring
+working sets — from run to run), and the "cold" workloads are synthetic
+worst cases — real renders are dominated by the cache-hit rows. On cnfast's
+own whole-repository replay suite, cnfast 0.2.0 is currently ~1.1× faster
+(geometric mean); cn wins the largest corpus. Both are microseconds per
+render pass either way.
 
 ## Size accounting
 
-Of the default entry's ~10.2 KB (min+gzip): compiled tables ≈ 5.4 KB, engine ≈
-4.8 KB. Compare tailwind-merge: config object ≈ 7.2 KB, engine ≈ 1.3 KB. Our
+Of the default entry's ~10.5 KB (min+gzip): compiled tables ≈ 5.4 KB, engine ≈
+5.1 KB. Compare tailwind-merge: config object ≈ 7.2 KB, engine ≈ 1.3 KB. Our
 data is smaller than theirs (the compiler dedupes and packs aggressively);
 our engine is bigger because the span validators, automaton, and conflict
 machinery are real code rather than regex/`Map` calls. That trade is the

--- a/packages/cn/src/engine.ts
+++ b/packages/cn/src/engine.ts
@@ -1075,9 +1075,44 @@ export const wrapClsx = (mergeString: (input: string) => string): CnFunction => 
             return resolveArgs([v0, v1, v2], true)
         }
         if (nArgs === 1) return mergeString(typeof v0 === 'string' ? v0 : resolveValue(v0 as ClassValue, true))
-        const vals: ClassValue[] = new Array(nArgs)
-        for (let i = 0; i < nArgs; i++) vals[i] = arguments[i]
-        return resolveArgs(vals, false)
+        // 4+ arity: probe predictions in place over `arguments` (indexed
+        // reads only, so it never materializes) — a predicted render-loop
+        // call allocates nothing. Only a genuine miss copies into an array
+        // for the resolve path.
+        const lh = lastHit
+        if (lh !== null) {
+            const pred = lh.n
+            if (pred !== null) {
+                const pa = pred.a
+                let k = 0
+                let ok = true
+                for (let i = 0; i < nArgs; i++) {
+                    const v = arguments[i]
+                    if (!v) continue
+                    if (v !== pa[k]) { ok = false; break }
+                    k++
+                }
+                if (ok && k === pred.t) {
+                    lastHit = pred
+                    return pred.r
+                }
+            }
+            if (lh !== pred) {
+                const la = lh.a
+                let k = 0
+                let ok = true
+                for (let i = 0; i < nArgs; i++) {
+                    const v = arguments[i]
+                    if (!v) continue
+                    if (v !== la[k]) { ok = false; break }
+                    k++
+                }
+                if (ok && k === lh.t) return lh.r
+            }
+        }
+        const vals: ClassValue[] = []
+        for (let i = 0; i < nArgs; i++) vals.push(arguments[i])
+        return resolveArgs(vals, true)
     } as CnFunction
 }
 

--- a/packages/conformance/package.json
+++ b/packages/conformance/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "clsx": "^2.1.1",
-    "cnfast": "^0.1.0",
+    "cnfast": "0.2.0",
     "esbuild": "^0.25.0",
     "tailwind-merge": "3.6.0"
   }

--- a/packages/conformance/speedlab/build.mjs
+++ b/packages/conformance/speedlab/build.mjs
@@ -202,6 +202,14 @@ const rev = (() => {
     }
 })()
 const meta = `Generated ${new Date().toISOString().slice(0, 16).replace('T', ' ')} UTC · Node ${process.version} · ${rev} · <code>pnpm speedlab</code>`
+const pkgVersion = (p) => JSON.parse(readFileSync(p, 'utf8')).version
+const versions = [
+    'cn ' + pkgVersion(join(repoRoot, 'packages/cn/package.json')),
+    'cnfast ' + pkgVersion(join(conformance, 'node_modules/cnfast/package.json')),
+    'tailwind-merge ' + pkgVersion(join(conformance, 'node_modules/tailwind-merge/package.json')),
+    'clsx ' + pkgVersion(join(conformance, 'node_modules/clsx/package.json')),
+].join(' · ')
+html = html.replace('<!--VERSIONS-->', versions)
 html = html.replace('<!--META-->', meta)
 html = html.replace('<!--REFERENCE_ROWS-->', referenceRows.join('\n') || '        <tr><td>skipped (--skip-bench)</td><td></td><td></td><td></td><td></td></tr>')
 html = html.replace('<!--REPO_SECTION-->', repoSection)

--- a/packages/conformance/speedlab/template.html
+++ b/packages/conformance/speedlab/template.html
@@ -448,7 +448,7 @@
       <code>npm run bench</code> in the cn repository.
     </p>
     <p>
-      Libraries bundled in this page: cn 0.1.0 · cnfast 0.1.0 · tailwind-merge
+      Libraries bundled in this page: <!--VERSIONS-->.1.0 · cnfast 0.1.0 · tailwind-merge
       3.6.0 · clsx 2.x. Output parity between cn and tailwind-merge is enforced
       by 356,000 differential tests in CI.
     </p>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       cnfast:
-        specifier: ^0.1.0
-        version: 0.1.0
+        specifier: 0.2.0
+        version: 0.2.0
       esbuild:
         specifier: ^0.25.0
         version: 0.25.12
@@ -461,8 +461,9 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
-  cnfast@0.1.0:
-    resolution: {integrity: sha512-rH0jBKeLkVrK7NsZ5Ba2l7WdMBmm1k0FMpABeXUU1PgTUxbz3261gEuCSsrYuXo4BwAe3yCcIbQ93YyS52lOGQ==}
+  cnfast@0.2.0:
+    resolution: {integrity: sha512-US4gOKGIylQWC7Nm+wNj+rOej6hJKyY4HwZYgtfRrduejEIFNNxcGKIWzCcQZxzgx6wKCZCCysWjnzsffiyhrw==}
+    engines: {node: '>=22'}
     hasBin: true
 
   dataloader@1.4.0:
@@ -1018,7 +1019,7 @@ snapshots:
 
   clsx@2.1.1: {}
 
-  cnfast@0.1.0: {}
+  cnfast@0.2.0: {}
 
   dataloader@1.4.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,7 @@
 packages:
   - packages/*
+
+# cnfast is a benchmark oracle in the private conformance package; we test
+# its releases the day they ship, so exclude it from the release-age hold.
+minimumReleaseAgeExclude:
+  - cnfast


### PR DESCRIPTION
cnfast 0.2.0 shipped this morning with its research-branch engine (sequence-predicting argument cache, engine-specific fronts, cold-path work). This PR re-measures everything against it and lands one engine improvement found in the process.

## Engine

**Allocation-free prediction for 4+ argument calls.** Profiling real-repository replays showed warm high-arity calls costing ~53ns: the dispatcher copied `arguments` into an array before probing the predictor, so even cache hits allocated. The probes now run in place over `arguments` (indexed reads only — never materialized); only a genuine miss copies. Warm high-arity calls drop to ~32ns and mixed-shape corpus replays improve up to 1.45×.

## Benchmarks (vs cnfast 0.2.0, same machine, isolated processes)

- README table re-measured; bold now marks the fastest implementation per row (both when tied) instead of always highlighting the `cn` column.
- cnfast 0.2.0 wins two warm rows by ~1ns and ties two; `cn` keeps the structural rows: cold merges (1.1µs vs 1.9µs), SSR streams (360ns vs 555ns), first call (0.4ms vs 4.3ms), and bundle size (26KB vs 40KB minified).
- The stale footnote claiming cnfast's cache is Chrome-only is gone (0.2.0 runs its cache everywhere).
- docs/how-it-works.md: refreshed caveats, including an honest note that cnfast 0.2.0 currently leads its own whole-repo replay suite by ~1.1× geomean — microseconds per render either way.

## Verification

- 56,346 differential + 100K fuzz + 5,054 custom-config + CLI e2e: all green
- size gate: 10,487 gz (budget 10,500); parse 26,148 vs cnfast's 40,164
- includes the cnfast 0.2.0 devDependency bump with the pnpm release-age exclusion for benchmark oracles