### PR TITLE
fix: broken published type declarations for cn/config and cn/lite

### DIFF
--- a/.changeset/violet-crabs-sing.md
+++ b/.changeset/violet-crabs-sing.md
@@ -1,0 +1,5 @@
+---
+"cn": patch
+---
+
+Fix broken published types: `cn/config` pointed at an internal chunk with mangled export names (no `defaultConfig`/`mergeConfigs`) and `cn/lite` typed `clsx` with zero parameters — runtime was unaffected, and the build now gates on every entry's declarations.

--- a/packages/cn/package.json
+++ b/packages/cn/package.json
@@ -80,7 +80,7 @@
     "bin"
   ],
   "scripts": {
-    "build": "tsdown",
+    "build": "tsdown && node scripts/check-dts.mjs",
     "compile-tables": "node scripts/compile-tables.mjs",
     "prepack": "node -e \"const fs=require('fs');fs.copyFileSync('../../README.md','README.md');fs.copyFileSync('../../LICENSE','LICENSE')\"",
     "postpack": "node -e \"const fs=require('fs');fs.rmSync('README.md',{force:true});fs.rmSync('LICENSE',{force:true})\""

--- a/packages/cn/scripts/check-dts.mjs
+++ b/packages/cn/scripts/check-dts.mjs
@@ -1,0 +1,143 @@
+// Post-build gate for the published type surface. Type-checks a consumer
+// fixture against dist/ through the real package.json `exports` map — the
+// ESM fixture resolves each entry's `import` types (.d.ts), the CJS fixture
+// the `require` types (.d.cts). Fails the build on what 0.2.1 shipped:
+// an entry's types resolving to an internal chunk with mangled export names,
+// and signatures narrower than the documented surface (zero-param `clsx`).
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+import ts from "typescript"
+
+const pkgRoot = fileURLToPath(new URL("..", import.meta.url))
+
+// Every public name of every entry, exercised with the argument shapes the
+// README documents. Adding an export? Add it here so the gate covers it.
+const fixture = `
+import {
+  cn, twMerge, clsx, createEngine, twJoin,
+  type ClassArray, type ClassDictionary, type ClassNameArray,
+  type ClassNameValue, type ClassValue, type CnConfig, type CnFunction,
+  type ConfigExtension, type CreateCnInput, type Engine, type EngineOptions,
+  type Tables, type ValidatorImpls,
+} from "cn"
+import {
+  clsx as engineClsx, createCn as engineCreateCn,
+  createEngine as engineCreateEngine, twJoin as engineTwJoin, wrapClsx,
+} from "cn/engine"
+import tables from "cn/tables"
+import {
+  createCn, createTwMerge, defaultConfig, extendTailwindMerge, fromTheme,
+  mergeConfigs, validators,
+  type ClassGroupDef, type DefaultClassGroupIds, type DefaultThemeGroupIds,
+} from "cn/config"
+import {
+  compileModel, compileStats, compileToSource, compileToTables, subsetConfig,
+  type CompileStats, type CompiledTables, type EmitOptions, type SubsetResult,
+} from "cn/compiler"
+import liteDefault, { clsx as liteClsx } from "cn/lite"
+
+// clsx-style variadic signatures (0.2.1 published lite's clsx as \`(): string\`)
+const sigs: ((...inputs: ClassValue[]) => string)[] = [
+  cn, clsx, liteClsx, liteDefault, engineClsx,
+]
+void sigs
+cn("p-2", ["p-4", { "text-sm": true }], undefined, 0, false && "x")
+liteClsx("a", false && "b", ["c"], null)
+twMerge("p-2 p-4", ["px-1", ["px-2"]])
+twJoin("a", ["b"], undefined)
+void engineTwJoin("a")
+
+// engine: compiled-tables pairing from the README
+const engine: Engine = createEngine(tables)
+void engineCreateEngine(tables)
+engine.merge("p-2", "p-4")
+engine.mergeString("p-2 p-4")
+const bound: CnFunction = engineCreateCn(tables)
+bound("p-2", { "p-4": true })
+wrapClsx(engine.mergeString)("p-2", ["p-4"])
+
+// config: custom-config surface
+const config: CnConfig = defaultConfig()
+const ext: ConfigExtension = {
+  extend: { classGroups: { "font-size": [{ text: ["hero"] }] } },
+}
+const merged: CnConfig = mergeConfigs(config, ext)
+const input: CreateCnInput = ext
+createCn(input)("p-2")
+createCn((c: CnConfig) => c)("p-2")
+createTwMerge(ext)("p-2 p-4")
+extendTailwindMerge(ext)("p-2 p-4")
+const themeRef: { $t: string } = fromTheme("spacing")
+const marker: { readonly $v: "isNumber" } = validators.isNumber
+const groupId: DefaultClassGroupIds = "aspect"
+const themeId: DefaultThemeGroupIds = "spacing"
+void [themeRef, marker, groupId, themeId]
+
+// compiler
+const compiled: CompiledTables = compileToTables(merged)
+createEngine(compiled.tables, compiled.validatorImpls)
+const emit: EmitOptions = { lang: "ts" }
+const source: string = compileToSource(merged, emit)
+void compileModel(merged)
+const stats: CompileStats = compileStats(merged)
+const subset: SubsetResult = subsetConfig(merged, ["p-2", "text-sm"])
+void [source, stats, subset]
+
+// type-only exports stay importable from every entry that declares them
+const groupDef: ClassGroupDef = { $t: "spacing" }
+const values: [
+  ClassArray, ClassDictionary, ClassNameArray, ClassNameValue, ClassValue,
+  EngineOptions, Tables, ValidatorImpls,
+] = [[], {}, [], "x", "y", {}, tables, {}]
+void [groupDef, values]
+`
+
+const dir = mkdtempSync(join(tmpdir(), "cn-check-dts-"))
+try {
+  mkdirSync(join(dir, "node_modules"))
+  symlinkSync(pkgRoot, join(dir, "node_modules", "cn"), "junction")
+  writeFileSync(join(dir, "package.json"), JSON.stringify({ type: "module" }))
+  writeFileSync(join(dir, "fixture.ts"), fixture)
+  writeFileSync(join(dir, "fixture.cts"), fixture)
+
+  const program = ts.createProgram(
+    [join(dir, "fixture.ts"), join(dir, "fixture.cts")],
+    {
+      strict: true,
+      noEmit: true,
+      target: ts.ScriptTarget.ES2022,
+      module: ts.ModuleKind.NodeNext,
+      moduleResolution: ts.ModuleResolutionKind.NodeNext,
+      esModuleInterop: true,
+      lib: ["lib.es2022.d.ts"],
+      types: [],
+    }
+  )
+  const diagnostics = ts.getPreEmitDiagnostics(program)
+  if (diagnostics.length > 0) {
+    console.error(
+      ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+        getCurrentDirectory: () => dir,
+        getCanonicalFileName: (f) => f,
+        getNewLine: () => "\n",
+      })
+    )
+    console.error(
+      `check-dts: ${diagnostics.length} error(s) — the type declarations in dist/ do not match the public surface`
+    )
+    process.exit(1)
+  }
+  console.log(
+    "check-dts: entry declarations OK (import/.d.ts and require/.d.cts)"
+  )
+} finally {
+  rmSync(dir, { recursive: true, force: true })
+}

--- a/packages/cn/src/compiler.ts
+++ b/packages/cn/src/compiler.ts
@@ -56,6 +56,16 @@ export interface ConfigExtension {
   >
 }
 
+/**
+ * Accepted config input: an `{ extend, override, prefix }` extension, a
+ * `(defaultConfig) => config` transform, or a complete config. Lives here
+ * (not in config.ts) so the `index` entry can re-export it without pulling
+ * config.ts into a shared declaration chunk that collides with the
+ * `cn/config` entry's own d.ts filename.
+ */
+export type CreateCnInput =
+  ConfigExtension | ((config: CnConfig) => CnConfig) | CnConfig
+
 const isMarker = (def: object, key: string): boolean => {
   const keys = Object.keys(def)
   return (

--- a/packages/cn/src/config.ts
+++ b/packages/cn/src/config.ts
@@ -10,6 +10,7 @@ import {
   type CnConfig,
   type ClassGroupDef,
   type ConfigExtension,
+  type CreateCnInput,
 } from "./compiler.js"
 import { getDefaultCnConfig } from "./default-config.generated.js"
 import { createEngine, wrapClsx } from "./engine.js"
@@ -17,7 +18,7 @@ import type { CnFunction, Engine } from "./types.js"
 
 export { getDefaultCnConfig as defaultConfig }
 export { mergeConfigs }
-export type { CnConfig, ClassGroupDef, ConfigExtension }
+export type { CnConfig, ClassGroupDef, ConfigExtension, CreateCnInput }
 export type {
   DefaultClassGroupIds,
   DefaultThemeGroupIds,
@@ -58,9 +59,6 @@ export const validators = {
   isArbitraryVariableShadow: { $v: "isArbitraryVariableShadow" },
   isArbitraryVariableWeight: { $v: "isArbitraryVariableWeight" },
 } as const
-
-export type CreateCnInput =
-  ConfigExtension | ((config: CnConfig) => CnConfig) | CnConfig
 
 const isFullConfig = (input: object): input is CnConfig =>
   "classGroups" in input &&

--- a/packages/cn/src/index.ts
+++ b/packages/cn/src/index.ts
@@ -17,8 +17,10 @@ export { clsx, createEngine, twJoin }
 // Custom configs live at "cn/config" (createCn, createTwMerge, fromTheme,
 // validators) — a separate entry so the compiler and default-config data
 // never enter this one's bundle graph. Compiled project tables pair with
-// createCn from "cn/engine".
-export type { CnConfig, ConfigExtension, CreateCnInput } from "./config.js"
+// createCn from "cn/engine". Types come from compiler.ts, not config.ts:
+// importing config.ts here would split its declarations into a shared chunk
+// whose filename can collide with the `cn/config` entry's own d.ts.
+export type { CnConfig, ConfigExtension, CreateCnInput } from "./compiler.js"
 
 export type {
   ClassArray,

--- a/packages/cn/src/lite.ts
+++ b/packages/cn/src/lite.ts
@@ -3,7 +3,12 @@
 // the `/lite` subpath. Join-only by design: this stands in for clsx's role
 // (joining), not cn's (merging).
 
-export function clsx(): string {
+import type { ClassValue } from "./types.js"
+
+// Typed as ClassValue[] (not string[]) because clsx serves its main
+// declarations for `/lite` too — a narrower signature here would reject
+// code that type-checks against clsx.
+export const clsx = function (): string {
   let str = ""
   for (let i = 0; i < arguments.length; i++) {
     const tmp = arguments[i]
@@ -13,6 +18,6 @@ export function clsx(): string {
     }
   }
   return str
-}
+} as (...inputs: ClassValue[]) => string
 
 export default clsx


### PR DESCRIPTION
Fixes the type declarations published in 0.2.1 (runtime was unaffected):

- `cn/config` types pointed at an internal chunk with mangled export names — `defaultConfig`, `mergeConfigs`, etc. were missing.
- `cn/lite` typed `clsx()` with no parameters, so every call was a type error.

Also adds a post-build check that fails the build if any entry's declarations break again.