### PR TITLE
fix: guard claim epoch against int32 wrap

### DIFF
--- a/.changeset/thick-pugs-tickle.md
+++ b/.changeset/thick-pugs-tickle.md
@@ -1,0 +1,5 @@
+---
+"cn": patch
+---
+
+Fix conflict detection silently failing after 2^31 cache-missing merges in one process.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
           FUZZ_ITERS: "300000"
       - run: node packages/conformance/tests/custom-config.mjs
       - run: node packages/conformance/tests/cli.mjs
+      - run: node packages/conformance/tests/hardening.mjs
       - name: size gate (default entry must stay smaller than cnfast)
         run: node packages/conformance/scripts/size.mjs
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,10 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
+          # no `cache: pnpm` here on purpose: the Actions cache is writable
+          # from lower-privileged workflow runs, and this job publishes with
+          # provenance — install from the registry, verified by the lockfile
           node-version: 24
-          cache: pnpm
           registry-url: https://registry.npmjs.org
       # trusted publishing needs npm >= 11.5.1 — pinned to the 11 line: npm 12
       # changed `npm info --json` to emit an array, which crashes the pnpm

--- a/packages/cn/src/engine.ts
+++ b/packages/cn/src/engine.ts
@@ -887,7 +887,15 @@ export const createEngine = (
       claimKeys = new Int32Array(CLAIM_TABLE)
       claimEpochs = new Int32Array(CLAIM_TABLE)
     }
-    epoch++
+    // epoch is stored in Int32Arrays, so it has to truncate the same way; on
+    // the wrap through 0 the tables must be cleared or unclaimed slots read
+    // as claimed
+    epoch = (epoch + 1) | 0
+    if (epoch === 0) {
+      claim0.fill(0)
+      claimEpochs.fill(0)
+      epoch = 1
+    }
     let didDrop = false
     for (let t = tokenCount - 1; t >= 0; t--) {
       const gid = tokGid[t]

--- a/packages/conformance/package.json
+++ b/packages/conformance/package.json
@@ -4,7 +4,7 @@
   "description": "Reference oracles and gates for cn: differential parity suites vs tailwind-merge + clsx, benchmark matrix vs the incumbents, bundle-size gate, and the vendored-config source of truth. Never published.",
   "type": "module",
   "scripts": {
-    "test": "node tests/correctness.mjs && node tests/fuzz.mjs && node tests/custom-config.mjs && node tests/cli.mjs",
+    "test": "node tests/correctness.mjs && node tests/fuzz.mjs && node tests/custom-config.mjs && node tests/cli.mjs && node tests/hardening.mjs",
     "test:src": "node tests/correctness.mjs --src && node tests/fuzz.mjs --src",
     "bench": "node bench/bench.mjs",
     "size": "node scripts/size.mjs",

--- a/packages/conformance/scripts/size.mjs
+++ b/packages/conformance/scripts/size.mjs
@@ -58,7 +58,8 @@ for (const r of rows)
 //      two-generation doorkeeper spent ~210 B of gzip to make the 30×
 //      headline reproducible and fix a 6-15× real-repo corpus regression;
 //      gzip sits ~7% over cnfast while parse stays well under
-//   3. absolute transfer budget: 10,500 B (creep tripwire)
+//   3. absolute transfer budget: 10,550 B (creep tripwire); raised from
+//      10,500 on 2026-09-01 for the int32 epoch guard (~20 B)
 const ours = rows[0]
 const cnfast = rows[4]
 let fail = false
@@ -74,11 +75,11 @@ if (ours.gz > cnfast.gz * 1.08) {
   )
   fail = true
 }
-if (ours.gz > 10500) {
-  console.error(`SIZE GATE FAIL (budget): cn ${ours.gz} > 10500`)
+if (ours.gz > 10550) {
+  console.error(`SIZE GATE FAIL (budget): cn ${ours.gz} > 10550`)
   fail = true
 }
 if (fail) process.exit(1)
 console.log(
-  `size gate ok: parse ${ours.min} < ${cnfast.min}; gzip ${ours.gz} (cnfast ${cnfast.gz}, band ${Math.round(cnfast.gz * 1.08)}); budget 10500`
+  `size gate ok: parse ${ours.min} < ${cnfast.min}; gzip ${ours.gz} (cnfast ${cnfast.gz}, band ${Math.round(cnfast.gz * 1.08)}); budget 10550`
 )

--- a/packages/conformance/tests/hardening.mjs
+++ b/packages/conformance/tests/hardening.mjs
@@ -1,0 +1,124 @@
+// Regression guard for the epoch int32 wrap fix in engine.ts.
+//
+// All other suites pass with the fix reverted (the bug needs 2^31 real
+// merges to fire), so this test builds patched copies of dist/engine.js
+// with `let epoch = 0` rewritten to start at each hazardous boundary:
+//
+//   A. 2147483640 — merges cross 2^31. With a plain `epoch++` the stored
+//      int32 truncates while the JS number keeps growing, claim stamps
+//      never match again, and every conflicting class is silently kept.
+//   B. -1 — the next merge lands on epoch 0 over cold tables, where
+//      unclaimed slots read as claimed: static conflicts drop every class
+//      (merge returns ""), and variant-context conflicts spin forever in
+//      claimTest's probe loop. Case B therefore runs in a child process
+//      under a timeout: the regression is a hang, not just wrong output.
+//
+// Only the skip-past-zero half is directly testable; the wrap fill also
+// prevents stamps from one 2^32 cycle aliasing the same epoch value a full
+// cycle later, which no test can reach. Engines are built with cacheSize 0
+// so every call is a real merge and bumps the epoch exactly once.
+import { execFileSync } from "node:child_process"
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+import tables from "cn/tables"
+import { twMerge as ref } from "tailwind-merge"
+
+const enginePath = fileURLToPath(
+  new URL("../../cn/dist/engine.js", import.meta.url)
+)
+const INIT = "let epoch = 0;"
+
+const engineAt = (dir, epochInit) => {
+  const src = readFileSync(enginePath, "utf8")
+  // fail loudly if the patch point is gone — a silently unpatched engine
+  // would make every case below pass without testing anything
+  if (src.split(INIT).length !== 2) {
+    throw new Error(
+      `hardening: expected exactly one \`${INIT}\` in dist/engine.js — ` +
+        "update this test to match the new engine shape"
+    )
+  }
+  const out = join(dir, `engine-epoch-${epochInit}.mjs`)
+  writeFileSync(out, src.replace(INIT, `let epoch = ${epochInit};`))
+  return out
+}
+
+// distinct multi-token inputs with conflicts in static and variant contexts
+const caseAt = (i) =>
+  `p-${i} p-${i + 1} text-red-500 text-blue-${(i % 9) + 1}00 flex block ` +
+  `hover:m-${i % 12} hover:m-${(i + 1) % 12} mx-${i}`
+
+const runMerges = async (file, count) => {
+  const { createEngine } = await import(pathToFileURL(file))
+  const engine = createEngine(tables, undefined, { cacheSize: 0 })
+  const bad = []
+  for (let i = 0; i < count; i++) {
+    const input = caseAt(i)
+    const got = engine.mergeString(input)
+    const want = ref(input)
+    if (got !== want) bad.push({ i, got, want })
+  }
+  return bad
+}
+
+// ---- child mode: the epoch-0 merges, run under the parent's timeout -------
+if (process.argv[2] === "--wrap-child") {
+  const bad = await runMerges(process.argv[3], 10)
+  for (const b of bad)
+    console.log(
+      `  merge ${b.i}: got ${JSON.stringify(b.got)}, want ${JSON.stringify(b.want)}`
+    )
+  process.exit(bad.length === 0 ? 0 : 1)
+}
+
+const dir = mkdtempSync(join(tmpdir(), "cn-hardening-"))
+let pass = 0
+let fail = 0
+const expect = (label, cond, detail = "") => {
+  if (cond) pass++
+  else {
+    fail++
+    console.log(`HARDENING FAIL [${label}] ${detail}`)
+  }
+}
+
+try {
+  // A. cross the int32 truncation boundary (merge 8 of 64 lands on 2^31)
+  const badA = await runMerges(engineAt(dir, 2147483640), 64)
+  expect(
+    "int32 truncation",
+    badA.length === 0,
+    badA.length
+      ? `${badA.length}/64 merges disagree with tailwind-merge past 2^31, ` +
+          `e.g. merge ${badA[0].i}: got ${JSON.stringify(badA[0].got)}`
+      : ""
+  )
+
+  // B. land on epoch 0 with cold tables. Must start at exactly -1: earlier
+  // merges warm the claimed gids and hide the misread. A regression hangs
+  // (variant contexts) or returns "" (static), so run under a timeout.
+  const wrapEngine = engineAt(dir, -1)
+  let wrapOk = true
+  let wrapDetail = ""
+  try {
+    execFileSync(
+      process.execPath,
+      [fileURLToPath(import.meta.url), "--wrap-child", wrapEngine],
+      { timeout: 30000, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }
+    )
+  } catch (e) {
+    wrapOk = false
+    wrapDetail =
+      e.signal !== null
+        ? `hang: killed by ${e.signal} after 30s (claimTest probe loop never exits at epoch 0)`
+        : `wrong output at epoch 0:\n${e.stdout ?? ""}`
+  }
+  expect("epoch-0 wrap", wrapOk, wrapDetail)
+} finally {
+  rmSync(dir, { recursive: true, force: true })
+}
+
+console.log(`hardening: pass ${pass}  fail ${fail}`)
+if (fail > 0) process.exit(1)


### PR DESCRIPTION
The merge-conflict epoch is compared against `Int32Array` claim slots but grew as a plain JS number. Past 2^31 the stored stamp truncates while the number keeps growing, so conflict detection silently turns off for the life of the process — every conflicting class is kept. Reachable in weeks of SSR uptime once the recurring class vocabulary outgrows the whole-string cache.

The fix truncates the increment to int32 and clears the claim tables on the wrap through 0, where unclaimed slots read as claimed (static conflicts return `""`; variant-context conflicts hang in the probe loop).

- `tests/hardening.mjs` covers both boundaries by patching the epoch start into dist and diffing against tailwind-merge; verified to fail against `epoch++` (57/64 mismatches) and against `|0` without the zero-clear (hang, caught by timeout)
- size tripwire 10,500 → 10,550: the guard costs 20 gzip bytes and no correct form fits the old 13-byte headroom
- release workflow no longer restores a shared cache before publishing with provenance
- changeset: patch