### PR TITLE
fix: claim-table bounds, cn build content scanning, and Unicode whitespace parity

### DIFF
--- a/.changeset/cli-content-scanning.md
+++ b/.changeset/cli-content-scanning.md
@@ -2,4 +2,4 @@
 "cn": patch
 ---
 
-`cn build`: fix `--content` brace globs (`src/**/*.{ts,tsx}` failed to parse), scan explicitly named dot- and ignored directories, follow symlinks, keep long arbitrary-value candidates, warn about unreadable files, create the output directory, and report file errors with the `cn:` prefix.
+Fix `cn build --content` brace globs, dot-directory and symlink scanning, and CLI error reporting.

--- a/.changeset/cli-content-scanning.md
+++ b/.changeset/cli-content-scanning.md
@@ -1,0 +1,5 @@
+---
+"cn": patch
+---
+
+`cn build`: fix `--content` brace globs (`src/**/*.{ts,tsx}` failed to parse), scan explicitly named dot- and ignored directories, follow symlinks, keep long arbitrary-value candidates, warn about unreadable files, create the output directory, and report file errors with the `cn:` prefix.

--- a/.changeset/engine-claim-bounds.md
+++ b/.changeset/engine-claim-bounds.md
@@ -1,0 +1,5 @@
+---
+"cn": patch
+---
+
+Fix conflict tracking for custom configs with large conflict fan-out (a merge could hang) and for merges with thousands of distinct arbitrary properties (classes were silently dropped); bound the variant-prefix intern cache.

--- a/.changeset/engine-claim-bounds.md
+++ b/.changeset/engine-claim-bounds.md
@@ -2,4 +2,4 @@
 "cn": patch
 ---
 
-Fix conflict tracking for custom configs with large conflict fan-out (a merge could hang) and for merges with thousands of distinct arbitrary properties (classes were silently dropped); bound the variant-prefix intern cache.
+Fix a hang and dropped classes in conflict tracking for large custom configs and merges.

--- a/.changeset/whitespace-join-parity.md
+++ b/.changeset/whitespace-join-parity.md
@@ -2,4 +2,4 @@
 "cn": patch
 ---
 
-Match tailwind-merge on Unicode whitespace separators (non-breaking space, ideographic space, BOM, and the rest of `\s`) and on `twJoin`'s handling of array-like values.
+Match tailwind-merge on Unicode whitespace and `twJoin` array-like values.

--- a/.changeset/whitespace-join-parity.md
+++ b/.changeset/whitespace-join-parity.md
@@ -1,0 +1,5 @@
+---
+"cn": patch
+---
+
+Match tailwind-merge on Unicode whitespace separators (non-breaking space, ideographic space, BOM, and the rest of `\s`) and on `twJoin`'s handling of array-like values.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       - run: node packages/conformance/tests/cli.mjs
       - run: node packages/conformance/tests/hardening.mjs
       - run: node packages/conformance/tests/bounds.mjs
+      - run: node packages/conformance/tests/join.mjs
       - name: size gate (default entry must stay smaller than cnfast)
         run: node packages/conformance/scripts/size.mjs
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
       - run: node packages/conformance/tests/custom-config.mjs
       - run: node packages/conformance/tests/cli.mjs
       - run: node packages/conformance/tests/hardening.mjs
+      - run: node packages/conformance/tests/bounds.mjs
       - name: size gate (default entry must stay smaller than cnfast)
         run: node packages/conformance/scripts/size.mjs
 

--- a/docs/build-setup.md
+++ b/docs/build-setup.md
@@ -47,6 +47,10 @@ export const cn = createCn(tables)
 lib/cn-tables.ts
 ```
 
+Patterns support `**`, `?`, and `{a,b}`; a pattern that names a dot-directory
+or a normally ignored directory such as `out/` scans it; symbolic links are
+followed.
+
 ## Next.js
 
 npm lifecycle hooks run automatically before `dev` and `build`:

--- a/packages/cn/bin/cn.mjs
+++ b/packages/cn/bin/cn.mjs
@@ -327,7 +327,7 @@ if (!opts.full) {
     if (!opts.quiet) {
       if (scanState.skippedUnreadable > 0)
         console.error(
-          `cn: skipped ${scanState.skippedUnreadable} unreadable file(s) or directorie(s)`
+          `cn: skipped ${scanState.skippedUnreadable} unreadable path(s)`
         )
       if (scanState.skippedLong > 0)
         console.error(

--- a/packages/cn/bin/cn.mjs
+++ b/packages/cn/bin/cn.mjs
@@ -14,8 +14,15 @@
 // classes never seen in your sources may instead pass through unmerged — they
 // have no CSS in your build anyway. Don't build class names by string
 // concatenation, or add them to the safelist if you must.
-import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs"
-import { join, resolve, sep } from "node:path"
+import {
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+  writeFileSync,
+} from "node:fs"
+import { basename, dirname, join, resolve, sep } from "node:path"
 import { pathToFileURL } from "node:url"
 import { gzipSync } from "node:zlib"
 
@@ -23,7 +30,9 @@ const args = process.argv.slice(2)
 const HELP = `Usage: cn build [options]
 
 Options:
-  --content <glob>     source globs to scan (repeatable or comma-separated)
+  --content <glob>     source globs to scan (repeatable or comma-separated;
+                       braces like *.{ts,tsx} are supported; a literal
+                       directory scans every file in it)
                        default: **/*.{js,jsx,ts,tsx,html,vue,svelte,astro,mdx}
   -o, --out <path>     output module path (default: cn-tables.mjs; .ts emits TS)
   --safelist <file>    extra class names, whitespace-separated
@@ -64,13 +73,32 @@ const opts = {
   cwd: process.cwd(),
   quiet: false,
 }
+// Split a --content value on commas that are not inside a {…} brace group,
+// so "src/**/*.{ts,tsx}" stays one pattern.
+const splitContent = (value) => {
+  const out = []
+  let depth = 0
+  let start = 0
+  for (let i = 0; i < value.length; i++) {
+    const c = value[i]
+    if (c === "{") depth++
+    else if (c === "}") depth = Math.max(0, depth - 1)
+    else if (c === "," && depth === 0) {
+      out.push(value.slice(start, i))
+      start = i + 1
+    }
+  }
+  out.push(value.slice(start))
+  return out.map((s) => s.trim()).filter(Boolean)
+}
+
 for (let i = 1; i < args.length; i++) {
   const a = args[i]
   const next = () => {
     if (i + 1 >= args.length) fail(`missing value for ${a}`)
     return args[++i]
   }
-  if (a === "--content") opts.content.push(...next().split(","))
+  if (a === "--content") opts.content.push(...splitContent(next()))
   else if (a === "-o" || a === "--out") opts.out = next()
   else if (a === "--safelist") opts.safelist = next()
   else if (a === "--config") opts.config = next()
@@ -128,25 +156,82 @@ const IGNORED_DIRS = new Set([
   ".vercel",
   ".output",
 ])
-const walk = (dir, rel, out) => {
+// Literal leading path of a glob: the segments before the first one that
+// contains a glob character. "src/**/*.ts" → "src"; "**/*.ts" → "".
+const literalPrefix = (pattern) => {
+  const segs = pattern.split("/")
+  const keep = []
+  for (const s of segs) {
+    if (/[*?{]/.test(s)) break
+    keep.push(s)
+  }
+  return keep.join("/")
+}
+
+const scanState = { skippedUnreadable: 0, skippedLong: 0 }
+
+// Walk `dir` (relative path `rel` from cwd), appending relative file paths.
+// `optIn` holds literal prefixes from the patterns; a normally-pruned
+// directory is entered when some prefix equals or descends into it.
+// Symlinks are followed via statSync; `ancestors` holds the real paths of
+// dir's own ancestors in the current recursion branch (added before, and
+// removed after, walking a directory's children), so a symlink pointing
+// back at one of its ancestors is caught as a cycle without also blocking
+// a legitimate second visit to the same real directory from an unrelated
+// branch (e.g. a symlink next to the directory it targets).
+const walk = (dir, rel, out, optIn, ancestors) => {
+  let real
+  try {
+    real = realpathSync(dir)
+  } catch {
+    scanState.skippedUnreadable++
+    return
+  }
+  if (ancestors.has(real)) return
+  ancestors.add(real)
   let entries
   try {
     entries = readdirSync(dir, { withFileTypes: true })
   } catch {
+    scanState.skippedUnreadable++
+    ancestors.delete(real)
     return
   }
   for (const e of entries) {
-    if (e.isDirectory()) {
-      if (IGNORED_DIRS.has(e.name) || e.name.startsWith(".")) continue
-      walk(join(dir, e.name), rel ? rel + "/" + e.name : e.name, out)
-    } else if (e.isFile()) {
-      out.push(rel ? rel + "/" + e.name : e.name)
+    const childRel = rel ? rel + "/" + e.name : e.name
+    const childAbs = join(dir, e.name)
+    let isDir = e.isDirectory()
+    let isFile = e.isFile()
+    if (e.isSymbolicLink()) {
+      try {
+        const st = statSync(childAbs)
+        isDir = st.isDirectory()
+        isFile = st.isFile()
+      } catch {
+        continue
+      }
+    }
+    if (isDir) {
+      if (e.name === ".git") continue
+      const pruned = IGNORED_DIRS.has(e.name) || e.name.startsWith(".")
+      if (
+        pruned &&
+        !optIn.some((p) => p === childRel || p.startsWith(childRel + "/"))
+      )
+        continue
+      walk(childAbs, childRel, out, optIn, ancestors)
+    } else if (isFile) {
+      out.push(childRel)
     }
   }
+  ancestors.delete(real)
 }
 const expandGlobs = (patterns, cwd) => {
   const files = new Set()
   let allFiles = null
+  const optIn = patterns
+    .map((raw) => literalPrefix(raw.replace(/\\/g, "/").replace(/^\.\//, "")))
+    .filter(Boolean)
   for (const raw of patterns) {
     const pattern = raw.replace(/\\/g, "/").replace(/^\.\//, "")
     if (!/[*?{]/.test(pattern)) {
@@ -161,14 +246,14 @@ const expandGlobs = (patterns, cwd) => {
       if (st.isFile()) files.add(p)
       else if (st.isDirectory()) {
         const sub = []
-        walk(p, "", sub)
+        walk(p, "", sub, [], new Set())
         for (const f of sub) files.add(join(p, f.split("/").join(sep)))
       }
       continue
     }
     if (allFiles === null) {
       allFiles = []
-      walk(cwd, "", allFiles)
+      walk(cwd, "", allFiles, optIn, new Set())
     }
     const re = globToRegex(pattern)
     for (const f of allFiles)
@@ -184,7 +269,12 @@ const extractTokens = (text, into) => {
   const matches = text.match(CANDIDATE_RE)
   if (!matches) return
   for (const m of matches) {
-    if (m.length > 0 && m.length < 256) into.add(m)
+    if (m.length === 0) continue
+    if (m.length > 8192) {
+      scanState.skippedLong++
+      continue
+    }
+    into.add(m)
   }
 }
 
@@ -195,7 +285,12 @@ const { defaultConfig } = await import("../dist/config.js")
 
 let config = defaultConfig()
 if (opts.config) {
-  const mod = await import(pathToFileURL(resolve(opts.cwd, opts.config)).href)
+  let mod
+  try {
+    mod = await import(pathToFileURL(resolve(opts.cwd, opts.config)).href)
+  } catch (err) {
+    fail(`cannot load config ${opts.config}: ${err.message}`)
+  }
   const ext = mod.default ?? mod.config
   if (!ext) fail(`config file ${opts.config} has no default export`)
   config = typeof ext === "function" ? ext(config) : mergeConfigs(config, ext)
@@ -205,9 +300,13 @@ const tokens = new Set()
 let scannedFiles = 0
 if (!opts.full) {
   if (opts.tokens) {
-    for (const t of readFileSync(resolve(opts.cwd, opts.tokens), "utf8").split(
-      /\s+/
-    )) {
+    let tokensText
+    try {
+      tokensText = readFileSync(resolve(opts.cwd, opts.tokens), "utf8")
+    } catch (err) {
+      fail(`cannot read tokens file ${opts.tokens}: ${err.message}`)
+    }
+    for (const t of tokensText.split(/\s+/)) {
       if (t) tokens.add(t)
     }
   } else {
@@ -222,15 +321,28 @@ if (!opts.full) {
         extractTokens(readFileSync(f, "utf8"), tokens)
         scannedFiles++
       } catch {
-        /* unreadable file: skip */
+        scanState.skippedUnreadable++
       }
+    }
+    if (!opts.quiet) {
+      if (scanState.skippedUnreadable > 0)
+        console.error(
+          `cn: skipped ${scanState.skippedUnreadable} unreadable file(s) or directorie(s)`
+        )
+      if (scanState.skippedLong > 0)
+        console.error(
+          `cn: skipped ${scanState.skippedLong} candidate token(s) longer than 8192 chars`
+        )
     }
   }
   if (opts.safelist) {
-    for (const t of readFileSync(
-      resolve(opts.cwd, opts.safelist),
-      "utf8"
-    ).split(/\s+/)) {
+    let safelistText
+    try {
+      safelistText = readFileSync(resolve(opts.cwd, opts.safelist), "utf8")
+    } catch (err) {
+      fail(`cannot read safelist ${opts.safelist}: ${err.message}`)
+    }
+    for (const t of safelistText.split(/\s+/)) {
       if (t) tokens.add(t)
     }
   }
@@ -249,7 +361,7 @@ const outPath = resolve(opts.cwd, opts.out)
 const lang = outPath.endsWith(".ts") ? "ts" : "js"
 const banner = `// GENERATED by \`cn build\` — do not edit.
 // Pair with createCn from "cn/engine":
-//   import tables from "./${opts.out.split("/").pop()}"
+//   import tables from "./${basename(outPath)}"
 //   import { createCn } from "cn/engine"
 //   export const cn = createCn(tables)`
 let source
@@ -258,7 +370,12 @@ try {
 } catch (err) {
   fail(String(err && err.message ? err.message : err))
 }
-writeFileSync(outPath, source)
+try {
+  mkdirSync(dirname(outPath), { recursive: true })
+  writeFileSync(outPath, source)
+} catch (err) {
+  fail(`cannot write ${opts.out}: ${err.message}`)
+}
 
 if (!opts.quiet) {
   const gz = gzipSync(source, { level: 9 }).length

--- a/packages/cn/src/engine.ts
+++ b/packages/cn/src/engine.ts
@@ -242,6 +242,10 @@ export const createEngine = (
     (c >= 48 && c <= 57) ||
     c === 95
 
+  // non-ascii members of js \s (u00a0, u1680, u2000-u200a, u2028/9, u202f,
+  // u205f, u3000, ufeff); only reached for code units >= 0xa0
+  const isUniWS = (c: number): boolean => /\s/.test(String.fromCharCode(c))
+
   const analyzeArb = (input: string, s: number, e: number): void => {
     aKind = 0
     aLabelS = -1
@@ -647,7 +651,7 @@ export const createEngine = (
     let i = 0
     while (i < n) {
       let c = input.charCodeAt(i)
-      if (c === 32 || (c >= 9 && c <= 13)) {
+      if (c === 32 || (c >= 9 && c <= 13) || (c >= 0xa0 && isUniWS(c))) {
         if (c !== 32) sawNonSpaceWS = true
         i++
         continue
@@ -665,6 +669,9 @@ export const createEngine = (
             break
           }
           // control chars 0-8/14-31 are token chars (parity)
+        } else if (c >= 0xa0 && isUniWS(c)) {
+          sawNonSpaceWS = true
+          break
         }
         th = Math.imul(th ^ c, 0x01000193)
         i++
@@ -1148,10 +1155,11 @@ const resolveValue = (v: ClassValue, clsxMode: boolean): string => {
   let out = ""
   if (
     typeof (v as { length?: unknown }).length === "number" &&
-    Array.isArray(v)
+    (clsxMode ? Array.isArray(v) : true)
   ) {
-    for (let i = 0; i < v.length; i++) {
-      const item = v[i]
+    const arr = v as ArrayLike<ClassValue>
+    for (let i = 0; i < arr.length; i++) {
+      const item = arr[i]
       if (!item) continue
       const r = typeof item === "string" ? item : resolveValue(item, clsxMode)
       if (r) {

--- a/packages/cn/src/engine.ts
+++ b/packages/cn/src/engine.ts
@@ -122,6 +122,17 @@ export const createEngine = (
   const adjRow = new Int32Array(GROUP_COUNT).fill(-1)
   for (let i = 0; i < adjGid.length; i++) adjRow[adjGid[i]] = i
 
+  // claims per kept token: itself + its adjacency row + postfix pairs;
+  // sizes the claim table so it can never fill under any config
+  let maxAdj = 0
+  for (let r = 0; r + 1 < adjStart.length; r++) {
+    const n = adjStart[r + 1] - adjStart[r]
+    if (n > maxAdj) maxAdj = n
+  }
+  let CLAIM_PER_TOKEN = 32
+  while (CLAIM_PER_TOKEN < 2 * (1 + maxAdj + patGid.length))
+    CLAIM_PER_TOKEN <<= 1
+
   // per-list gid offsets (lists share op patterns; gids are flat per list)
   const vgStart = new Int32Array(vlistRef.length + 1)
   for (let l = 0; l < vlistRef.length; l++) {
@@ -452,6 +463,7 @@ export const createEngine = (
   let nextDynId = GROUP_COUNT
   const MAX_DYN = GROUP_COUNT + 4096
   const newDynId = () => nextDynId++
+  const ID_LIMIT = 2097152 // 2^21: keeps ctx * 2^21 + gid exact in a double
 
   // ---- token memo (process lifetime, 2-way set-associative) --------------
   // full token span → (gid, ctxId, flags); hit verifies chars in place, so
@@ -525,11 +537,11 @@ export const createEngine = (
   const claim0 = new Int32Array(GROUP_COUNT)
 
   // unified claim set for the rest (variant contexts, dynamic groups):
-  // epoch-stamped open-addressed (ctxId, gid) keys — both are dense ids
-  // (ctxId ≤ 4096, gid < GROUP_COUNT + 4096), so they pack directly
+  // epoch-stamped open-addressed (ctxId, gid) keys stored as exact doubles —
+  // ids are bounded per merge by ID_LIMIT
   let CLAIM_TABLE = 2048
   let claimShift = 21 // 32 - log2(CLAIM_TABLE)
-  let claimKeys = new Int32Array(CLAIM_TABLE)
+  let claimKeys = new Float64Array(CLAIM_TABLE)
   let claimEpochs = new Int32Array(CLAIM_TABLE)
   let epoch = 0
   // test-and-claim in one probe: returns 1 if (ctx, gid) was already
@@ -540,7 +552,7 @@ export const createEngine = (
       claim0[gid] = epoch
       return 0
     }
-    const key = ((ctx << 13) | gid) + 1
+    const key = ctx * 2097152 + gid + 1
     let idx = Math.imul(key, 0x9e3779b1) >>> claimShift
     for (;;) {
       if (claimEpochs[idx] !== epoch) break // free slot
@@ -620,7 +632,7 @@ export const createEngine = (
     let sawNonSpaceWS = false
 
     // bounded-growth resets, between merges only
-    if (nextCtxId > MAX_CTX) {
+    if (nextCtxId > MAX_CTX || ctxByHash.size > MAX_CTX) {
       ctxByHash = new Map()
       ctxByCanon = new Map()
       nextCtxId = 2
@@ -891,16 +903,19 @@ export const createEngine = (
     }
 
     // ===== backward claim pass ============================================
-    // worst-case claims = tokens x (1 + max fan-out); keep load factor
-    // under 50% so probes stay short and the table can never fill
-    if (tokenCount * 32 > CLAIM_TABLE) {
-      while (tokenCount * 32 > CLAIM_TABLE) {
+    // worst-case claims = tokens x CLAIM_PER_TOKEN, where CLAIM_PER_TOKEN is
+    // derived from the tables' real max fan-out; keep load factor under 50%
+    // so probes stay short and the table can never fill
+    if (tokenCount * CLAIM_PER_TOKEN > CLAIM_TABLE) {
+      while (tokenCount * CLAIM_PER_TOKEN > CLAIM_TABLE) {
         CLAIM_TABLE <<= 1
         claimShift--
       }
-      claimKeys = new Int32Array(CLAIM_TABLE)
+      claimKeys = new Float64Array(CLAIM_TABLE)
       claimEpochs = new Int32Array(CLAIM_TABLE)
     }
+    if (nextCtxId >= ID_LIMIT || nextDynId >= ID_LIMIT)
+      throw new Error("cn: too many distinct classes in one merge")
     // epoch is stored in Int32Arrays, so it has to truncate the same way; on
     // the wrap through 0 the tables must be cleared or unclaimed slots read
     // as claimed

--- a/packages/conformance/package.json
+++ b/packages/conformance/package.json
@@ -4,7 +4,7 @@
   "description": "Reference oracles and gates for cn: differential parity suites vs tailwind-merge + clsx, benchmark matrix vs the incumbents, bundle-size gate, and the vendored-config source of truth. Never published.",
   "type": "module",
   "scripts": {
-    "test": "node tests/correctness.mjs && node tests/fuzz.mjs && node tests/custom-config.mjs && node tests/cli.mjs && node tests/hardening.mjs && node tests/bounds.mjs",
+    "test": "node tests/correctness.mjs && node tests/fuzz.mjs && node tests/custom-config.mjs && node tests/cli.mjs && node tests/hardening.mjs && node tests/bounds.mjs && node tests/join.mjs",
     "test:src": "node tests/correctness.mjs --src && node tests/fuzz.mjs --src",
     "bench": "node bench/bench.mjs",
     "bench:corpus": "node bench/corpus.mjs",

--- a/packages/conformance/package.json
+++ b/packages/conformance/package.json
@@ -4,7 +4,7 @@
   "description": "Reference oracles and gates for cn: differential parity suites vs tailwind-merge + clsx, benchmark matrix vs the incumbents, bundle-size gate, and the vendored-config source of truth. Never published.",
   "type": "module",
   "scripts": {
-    "test": "node tests/correctness.mjs && node tests/fuzz.mjs && node tests/custom-config.mjs && node tests/cli.mjs && node tests/hardening.mjs",
+    "test": "node tests/correctness.mjs && node tests/fuzz.mjs && node tests/custom-config.mjs && node tests/cli.mjs && node tests/hardening.mjs && node tests/bounds.mjs",
     "test:src": "node tests/correctness.mjs --src && node tests/fuzz.mjs --src",
     "bench": "node bench/bench.mjs",
     "bench:corpus": "node bench/corpus.mjs",

--- a/packages/conformance/scripts/size.mjs
+++ b/packages/conformance/scripts/size.mjs
@@ -74,7 +74,8 @@ for (const r of rows)
 //      2026-09-02 for the claim-table fix (~130 B: Float64 claim keys so
 //      group ids cannot alias, a tables-derived claim factor so wide
 //      custom conflict groups cannot fill the table, and a per-merge id
-//      guard)
+//      guard), and to 11,000 on 2026-09-02 for Unicode whitespace parity
+//      (~77 B: \s-complete separator scan and twJoin array-like values)
 const ours = rows[0]
 const cnfast = rows[4]
 let fail = false
@@ -90,13 +91,13 @@ if (ours.gz > cnfast.gz * 1.08) {
   )
   fail = true
 }
-if (ours.gz > 10950) {
-  console.error(`SIZE GATE FAIL (budget): cn ${ours.gz} > 10950`)
+if (ours.gz > 11000) {
+  console.error(`SIZE GATE FAIL (budget): cn ${ours.gz} > 11000`)
   fail = true
 }
 if (fail) process.exit(1)
 console.log(
-  `size gate ok: parse ${ours.min} < ${cnfast.min}; gzip ${ours.gz} (cnfast ${cnfast.gz}, band ${Math.round(cnfast.gz * 1.08)}); budget 10950`
+  `size gate ok: parse ${ours.min} < ${cnfast.min}; gzip ${ours.gz} (cnfast ${cnfast.gz}, band ${Math.round(cnfast.gz * 1.08)}); budget 11000`
 )
 
 // ---------------------------------------------------------------------------

--- a/packages/conformance/scripts/size.mjs
+++ b/packages/conformance/scripts/size.mjs
@@ -70,7 +70,11 @@ for (const r of rows)
 //      strings (~130 B; 0.16x-0.43x on sites with a dynamic arbitrary
 //      value, 0.83x cold arbitrary-value renders), and to 10,800 for the
 //      JSC-only Map substrate of the whole-string cache (~50 B;
-//      0.27x-0.31x on 8k-string working sets on bun)
+//      0.27x-0.31x on 8k-string working sets on bun), and to 10,950 on
+//      2026-09-02 for the claim-table fix (~130 B: Float64 claim keys so
+//      group ids cannot alias, a tables-derived claim factor so wide
+//      custom conflict groups cannot fill the table, and a per-merge id
+//      guard)
 const ours = rows[0]
 const cnfast = rows[4]
 let fail = false
@@ -86,13 +90,13 @@ if (ours.gz > cnfast.gz * 1.08) {
   )
   fail = true
 }
-if (ours.gz > 10800) {
-  console.error(`SIZE GATE FAIL (budget): cn ${ours.gz} > 10800`)
+if (ours.gz > 10950) {
+  console.error(`SIZE GATE FAIL (budget): cn ${ours.gz} > 10950`)
   fail = true
 }
 if (fail) process.exit(1)
 console.log(
-  `size gate ok: parse ${ours.min} < ${cnfast.min}; gzip ${ours.gz} (cnfast ${cnfast.gz}, band ${Math.round(cnfast.gz * 1.08)}); budget 10800`
+  `size gate ok: parse ${ours.min} < ${cnfast.min}; gzip ${ours.gz} (cnfast ${cnfast.gz}, band ${Math.round(cnfast.gz * 1.08)}); budget 10950`
 )
 
 // ---------------------------------------------------------------------------

--- a/packages/conformance/tests/bounds.mjs
+++ b/packages/conformance/tests/bounds.mjs
@@ -1,0 +1,157 @@
+// Regression guard for the claim-set bounds fix in engine.ts.
+//
+// Three hazards, none reachable by the other suites (they use the default
+// tables, short strings, and a fixed variant pool):
+//
+// A. A custom config whose class group conflicts with 31+ others can fill
+//    the (previously fixed-size) claim table, and the probe loop then spins
+//    forever. This case runs in a child process under a timeout so a hang
+//    is a test failure, not a CI stall.
+// B. The claim key used to pack the group id into 13 bits, so group ids
+//    above 8191 alias into the context bits and one class is silently
+//    dropped. Reachable with the stock default tables given enough distinct
+//    arbitrary properties.
+// C. The raw-variant-prefix intern map was reset only on the canonical
+//    context counter, so different orderings of the same variants leave it
+//    growing without bound. This case exercises the reset path rather than
+//    observing the bound directly.
+import { execFileSync } from "node:child_process"
+import { fileURLToPath } from "node:url"
+import { twMerge } from "cn"
+import { twMerge as ref } from "tailwind-merge"
+
+let pass = 0
+let fail = 0
+const expect = (label, cond, detail = "") => {
+  if (cond) pass++
+  else {
+    fail++
+    console.log(`BOUNDS FAIL [${label}] ${detail}`)
+  }
+}
+
+// ---- child mode: the fan-out merge, run under the parent's timeout --------
+if (process.argv[2] === "--wrap-child") {
+  const { createTwMerge } = await import("cn/config")
+  const { extendTailwindMerge } = await import("tailwind-merge")
+
+  const N = 100
+  const classGroups = { big: ["big"] }
+  const targets = []
+  for (let i = 0; i < N; i++) {
+    classGroups["t" + i] = ["t" + i]
+    targets.push("t" + i)
+  }
+  const ext = {
+    extend: { classGroups, conflictingClassGroups: { big: targets } },
+  }
+  const ours = createTwMerge(ext)
+  const theirs = extendTailwindMerge(ext)
+  const parts = []
+  for (let i = 0; i < 64; i++) parts.push(`v${i}:big`)
+  const input = parts.join(" ")
+  // exit 0 on parity, 1 on mismatch; a hang is caught by the parent's timeout
+  process.exit(ours(input) === theirs(input) ? 0 : 1)
+}
+
+// ---- A: wide conflict fan-out must not hang the claim table ---------------
+{
+  let ok = true
+  let detail = ""
+  try {
+    execFileSync(
+      process.execPath,
+      [fileURLToPath(import.meta.url), "--wrap-child"],
+      { timeout: 30000, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }
+    )
+  } catch (e) {
+    ok = false
+    detail =
+      e.signal !== null
+        ? `hang: killed by ${e.signal} after 30s (claim table filled and the probe loop never exits)`
+        : `mismatch vs tailwind-merge:\n${e.stdout ?? ""}${e.stderr ?? ""}`
+  }
+  expect("fan-out-hang", ok, detail)
+}
+
+// ---- B: group ids above 8191 must not alias --------------------------------
+{
+  const toks = []
+  for (let i = 0; i < 9000; i++) toks.push(`hover:[p${i}:x]`, `focus:[p${i}:x]`)
+  const big = toks.join(" ")
+  const got = twMerge(big)
+  const want = ref(big)
+  const gotCount = got.length ? got.split(" ").length : 0
+  const wantCount = want.length ? want.split(" ").length : 0
+  expect(
+    "gid-overflow",
+    got === want,
+    got === want
+      ? ""
+      : `class count ${gotCount} vs tailwind-merge's ${wantCount} (dropped ${wantCount - gotCount})`
+  )
+}
+
+// ---- C: raw-prefix intern map reset keeps results correct ------------------
+{
+  const variants = ["hover", "focus", "dark", "md", "lg", "sm", "first", "last"]
+  // Heap's algorithm: every permutation of `variants`, in place.
+  const perms = []
+  const a = variants.slice()
+  const c = new Array(a.length).fill(0)
+  perms.push(a.slice())
+  let i = 0
+  while (i < a.length) {
+    if (c[i] < i) {
+      if (i % 2 === 0) [a[0], a[i]] = [a[i], a[0]]
+      else [a[c[i]], a[i]] = [a[i], a[c[i]]]
+      perms.push(a.slice())
+      c[i]++
+      i = 0
+    } else {
+      c[i] = 0
+      i++
+    }
+  }
+
+  let mismatches = 0
+  let firstBad = null
+  for (const perm of perms) {
+    const prefix = perm.join(":")
+    const input = `${prefix}:p-1 ${prefix}:p-2`
+    const got = twMerge(input)
+    const want = ref(input)
+    if (got !== want) {
+      mismatches++
+      if (!firstBad) firstBad = { input, got, want }
+    }
+  }
+
+  // re-check a fixed set of earlier inputs after the sweep so the
+  // post-reset engine is exercised, not just the last permutation seen
+  const recheck = []
+  for (let i = 0; i < 20; i++) {
+    const perm = perms[i % perms.length]
+    const prefix = perm.join(":")
+    recheck.push(`${prefix}:p-1 ${prefix}:p-2 text-red-500 hover:m-${i}`)
+  }
+  for (const input of recheck) {
+    const got = twMerge(input)
+    const want = ref(input)
+    if (got !== want) {
+      mismatches++
+      if (!firstBad) firstBad = { input, got, want }
+    }
+  }
+
+  expect(
+    "raw-prefix-reset",
+    mismatches === 0,
+    mismatches
+      ? `${mismatches}/${perms.length + recheck.length} inputs disagree, e.g. ${JSON.stringify(firstBad)}`
+      : ""
+  )
+}
+
+console.log(`bounds: pass ${pass}  fail ${fail}`)
+if (fail > 0) process.exit(1)

--- a/packages/conformance/tests/cli.mjs
+++ b/packages/conformance/tests/cli.mjs
@@ -1,10 +1,20 @@
 // End-to-end test for `cn build`: scan a fixture project, emit tables,
 // verify subset parity for in-corpus classes and passthrough for the rest.
-import { execFileSync } from "node:child_process"
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { execFileSync, spawnSync } from "node:child_process"
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { fileURLToPath, pathToFileURL } from "node:url"
+import { createCn } from "cn/engine"
 import { twMerge as ref } from "tailwind-merge"
 
 const bin = fileURLToPath(new URL("../../cn/bin/cn.mjs", import.meta.url))
@@ -53,7 +63,6 @@ try {
 
   const t1 = (await import(pathToFileURL(join(dir, "tables-subset.mjs")).href))
     .default
-  const { createCn } = await import("cn/engine")
   const cn1 = createCn(t1)
 
   // in-corpus classes must merge byte-identically to full tailwind-merge
@@ -156,6 +165,223 @@ try {
     "text-lg/7 text-xl",
   ]) {
     expect("full-parity", cn4(s) === ref(s), JSON.stringify(s))
+  }
+
+  // ---- nested fixture tree for --content patterns ----------------------------
+  // Each file carries a class from a group nothing else in the fixture uses,
+  // so presence in the emitted tables proves the file was scanned. This is
+  // added only now, after the subset-build assertions above have already run,
+  // because the default glob (no --content) walks the whole fixture dir and
+  // would otherwise pull "list-disc" into the subset-passthrough check.
+  mkdirSync(join(dir, "src", "ui"), { recursive: true })
+  mkdirSync(join(dir, ".storybook"), { recursive: true })
+  mkdirSync(join(dir, "out"), { recursive: true })
+  mkdirSync(join(dir, "linked-src"), { recursive: true })
+  writeFileSync(join(dir, "src", "a.ts"), `const a = "columns-2"`)
+  writeFileSync(join(dir, "src", "ui", "b.tsx"), `const b = "list-disc"`)
+  writeFileSync(join(dir, "src", "ui", "c.css"), `.x { }`)
+  writeFileSync(join(dir, ".storybook", "s.tsx"), `const s = "float-left"`)
+  writeFileSync(join(dir, "out", "o.html"), `<i class="clear-both"></i>`)
+  writeFileSync(join(dir, "linked-src", "l.tsx"), `const l = "isolate"`)
+  symlinkSync(join(dir, "linked-src"), join(dir, "src", "linked"), "junction")
+  writeFileSync(
+    join(dir, "src", "long.tsx"),
+    `const l = "bg-[url(data:image/svg+xml;base64,${"A".repeat(400)})]"`
+  )
+  // Written here (rather than relying on the pre-extracted-tokens block
+  // below) so the out-mkdir case further down can rely on it existing.
+  writeFileSync(join(dir, "tokens.txt"), "p-2 px-4 hover:bg-red-500\n")
+
+  // Uses spawnSync (rather than execFileSync) so stderr is captured on a
+  // successful (status 0) run too — execFileSync only exposes stderr via
+  // the thrown error, which a zero-exit run never throws.
+  const run = (argv) => {
+    const r = spawnSync(process.execPath, [bin, ...argv], { encoding: "utf8" })
+    return { status: r.status, stdout: r.stdout ?? "", stderr: r.stderr ?? "" }
+  }
+  const groupsOf = async (file) => {
+    const t = (await import(pathToFileURL(join(dir, file)).href)).default
+    return createCn(t)
+  }
+
+  // ---- --content brace globs, explicit dot-dir, symlinks, long tokens ------
+  {
+    const r = run([
+      "build",
+      "--cwd",
+      dir,
+      "--content",
+      "src/**/*.{ts,tsx}",
+      "-o",
+      "t-brace.mjs",
+      "-q",
+    ])
+    expect("content-brace-exit", r.status === 0, r.stderr)
+    const c = await groupsOf("t-brace.mjs")
+    expect(
+      "content-brace-ts",
+      c("columns-2 columns-3") === ref("columns-2 columns-3")
+    )
+    expect(
+      "content-brace-tsx",
+      c("list-disc list-none") === ref("list-disc list-none")
+    )
+    // c.css did not match the pattern, and .storybook was not named.
+    expect(
+      "content-brace-excludes-dotdir",
+      c("float-left float-right") === "float-left float-right"
+    )
+    // The symlinked directory under src/ was followed.
+    expect(
+      "content-symlink",
+      c("isolate isolation-auto") === ref("isolate isolation-auto")
+    )
+    // A 400+ char arbitrary value was not dropped by a length cap.
+    expect(
+      "content-long-token",
+      c("bg-[url(x)] bg-red-500") === ref("bg-[url(x)] bg-red-500")
+    )
+  }
+  {
+    const r = run([
+      "build",
+      "--cwd",
+      dir,
+      "--content",
+      ".storybook/**/*.tsx,out/**/*.html",
+      "-o",
+      "t-dot.mjs",
+      "-q",
+    ])
+    expect("content-dotdir-exit", r.status === 0, r.stderr)
+    const c = await groupsOf("t-dot.mjs")
+    expect(
+      "content-dotdir-scanned",
+      c("float-left float-right") === ref("float-left float-right")
+    )
+    expect(
+      "content-ignored-dir-named",
+      c("clear-both clear-left") === ref("clear-both clear-left")
+    )
+  }
+  {
+    // Comma-separated list without braces still works.
+    const r = run([
+      "build",
+      "--cwd",
+      dir,
+      "--content",
+      "src/*.ts,src/ui/*.tsx",
+      "-o",
+      "t-comma.mjs",
+      "-q",
+    ])
+    expect("content-comma-exit", r.status === 0, r.stderr)
+  }
+
+  // ---- error paths use the cn: prefix and exit 1 ----------------------------
+  const errCase = (label, argv, needle) => {
+    const r = run(argv)
+    expect(
+      label,
+      r.status === 1 &&
+        r.stderr.startsWith("cn: ") &&
+        r.stderr.includes(needle),
+      `${r.status} ${r.stderr}`
+    )
+  }
+  errCase("err-unknown-command", ["frobnicate"], "unknown command")
+  errCase("err-unknown-option", ["build", "--nope"], "unknown option")
+  errCase("err-missing-value", ["build", "--content"], "missing value")
+  errCase(
+    "err-unclosed-brace",
+    ["build", "--cwd", dir, "--content", "src/*.{ts"],
+    "unclosed {"
+  )
+  errCase(
+    "err-no-match",
+    ["build", "--cwd", dir, "--content", "nothing/**/*.zzz"],
+    "no files matched"
+  )
+  errCase(
+    "err-bad-safelist",
+    ["build", "--cwd", dir, "--safelist", "missing.txt"],
+    "missing.txt"
+  )
+  errCase(
+    "err-bad-tokens",
+    ["build", "--cwd", dir, "--tokens", "missing.txt"],
+    "missing.txt"
+  )
+  errCase(
+    "err-bad-config",
+    ["build", "--cwd", dir, "--config", "missing.mjs", "--full"],
+    "missing.mjs"
+  )
+  writeFileSync(join(dir, "noexport.mjs"), "export const x = 1\n")
+  errCase(
+    "err-config-no-default",
+    ["build", "--cwd", dir, "--config", "noexport.mjs", "--full"],
+    "no default export"
+  )
+
+  // ---- output directory is created; help and version --------------------------
+  {
+    const r = run([
+      "build",
+      "--cwd",
+      dir,
+      "--tokens",
+      "tokens.txt",
+      "-o",
+      "deep/nested/t.mjs",
+      "-q",
+    ])
+    expect(
+      "out-mkdir",
+      r.status === 0 && existsSync(join(dir, "deep", "nested", "t.mjs")),
+      r.stderr
+    )
+  }
+  {
+    const r = run(["--help"])
+    expect(
+      "help",
+      r.status === 0 && r.stdout.includes("Usage: cn build"),
+      r.stdout
+    )
+  }
+  {
+    const pkg = JSON.parse(
+      readFileSync(new URL("../../cn/package.json", import.meta.url), "utf8")
+    )
+    const r = run(["--version"])
+    expect(
+      "version",
+      r.status === 0 && r.stdout.trim() === pkg.version,
+      r.stdout
+    )
+  }
+
+  // ---- unreadable files are reported, not hidden -----------------------------
+  if (process.platform !== "win32" && process.getuid?.() !== 0) {
+    writeFileSync(join(dir, "src", "secret.tsx"), `const s = "sr-only"`)
+    chmodSync(join(dir, "src", "secret.tsx"), 0o000)
+    const r = run([
+      "build",
+      "--cwd",
+      dir,
+      "--content",
+      "src/**/*.tsx",
+      "-o",
+      "t-unread.mjs",
+    ])
+    expect(
+      "unreadable-warned",
+      r.status === 0 && r.stderr.includes("skipped 1 unreadable"),
+      r.stderr
+    )
+    chmodSync(join(dir, "src", "secret.tsx"), 0o644)
   }
 
   // ---- pre-extracted tokens mode ----------------------------------------------

--- a/packages/conformance/tests/correctness.mjs
+++ b/packages/conformance/tests/correctness.mjs
@@ -215,6 +215,15 @@ const batteries = {
     " px-2 px-4",
     "px-2 px-4 ",
   ],
+  unicodeWhitespace: [
+    "p-4 p-2",
+    "p-4\u3000p-2 px-1",
+    "\ufeffp-4 p-2",
+    "hover:p-4 hover:p-2",
+    "p-4  p-2",
+    "p-4   p-2",
+    "text-lg text-sm text-xs",
+  ],
   lookalikes: [
     "text-lg text-10xl",
     "text-sm text-2xs",

--- a/packages/conformance/tests/fuzz.mjs
+++ b/packages/conformance/tests/fuzz.mjs
@@ -239,7 +239,22 @@ for (let i = 0; i < ITERS; i++) {
   const parts = []
   for (let k = 0; k < len; k++) parts.push(mkToken())
   // occasionally messy whitespace
-  const sep = rnd() < 0.03 ? "  " : rnd() < 0.02 ? "\t" : " "
+  const sep =
+    rnd() < 0.03
+      ? "  "
+      : rnd() < 0.02
+        ? "\t"
+        : rnd() < 0.01
+          ? pick([
+              "\u00a0",
+              "\u3000",
+              "\u2028",
+              "\ufeff",
+              "\u2003",
+              "\u205f",
+              "\u1680",
+            ])
+          : " "
   const s =
     (rnd() < 0.02 ? " " : "") + parts.join(sep) + (rnd() < 0.02 ? "\n" : "")
   const expected = ref(s)

--- a/packages/conformance/tests/join.mjs
+++ b/packages/conformance/tests/join.mjs
@@ -1,0 +1,143 @@
+// Differential suite for the join layer (clsx / twJoin / clsx-lite value
+// shapes), run against the BUILT package (dist/). Run: node tests/join.mjs
+import { clsx as refClsx } from "clsx"
+import { clsx as refLite } from "clsx/lite"
+import { clsx, twJoin } from "cn"
+import { clsx as liteClsx } from "cn/lite"
+import { twJoin as refTwJoin } from "tailwind-merge"
+
+const ITERS = Number(process.env.JOIN_ITERS ?? 20000)
+
+let seed = 0x5eed1234
+const rnd = () => {
+  seed ^= seed << 13
+  seed >>>= 0
+  seed ^= seed >> 17
+  seed ^= seed << 5
+  seed >>>= 0
+  return seed / 0x100000000
+}
+const pick = (arr) => arr[Math.floor(rnd() * arr.length)]
+
+let pass = 0
+let fail = 0
+const report = []
+const bigintReplacer = (k, v) =>
+  typeof v === "bigint" ? v.toString() + "n" : v
+const diff = (label, args, expected, actual) => {
+  if (expected === actual) pass++
+  else {
+    fail++
+    if (report.length < 30) report.push({ label, args, expected, actual })
+  }
+}
+const hand = (label, actual, expected) => diff(label, "-", expected, actual)
+
+// value generator, recursive with depth <= 3.
+const mkValue = (depth) => {
+  const r = rnd()
+  if (r < 0.35)
+    return pick(["p-2", "px-4", "text-sm", "hover:p-1", "", "a b", " "])
+  if (r < 0.45) return pick([null, undefined, false, 0, 0n, NaN, ""])
+  if (r < 0.55) return pick([1, 2, 42, -1, 3n, true])
+  if (r < 0.75 && depth < 3) {
+    const arr = []
+    const n = Math.floor(rnd() * 4)
+    for (let i = 0; i < n; i++) arr.push(mkValue(depth + 1))
+    return arr
+  }
+  if (r < 0.9) {
+    const o = {}
+    const n = Math.floor(rnd() * 4)
+    for (let i = 0; i < n; i++)
+      o[pick(["p-2", "flex", "block", "x", ""])] = pick([
+        true,
+        false,
+        1,
+        0,
+        "y",
+        null,
+      ])
+    return o
+  }
+  // array-like object (not an array).
+  return { length: 2, 0: pick(["p-4", ""]), 1: pick(["m-2", null]) }
+}
+
+const mkStringlyValue = () =>
+  pick(["p-2", "px-4", "text-sm", "", null, undefined, false, 0, NaN])
+
+// ---------- 1. clsx (cn) vs clsx (reference) --------------------------------
+for (let i = 0; i < ITERS; i++) {
+  const args = []
+  const n = Math.floor(rnd() * 6)
+  for (let k = 0; k < n; k++) args.push(mkValue(0))
+  diff(
+    "clsx",
+    JSON.stringify(args, bigintReplacer),
+    refClsx(...args),
+    clsx(...args)
+  )
+}
+
+// ---------- 2. twJoin (cn) vs twJoin (reference) ----------------------------
+for (let i = 0; i < ITERS; i++) {
+  const args = []
+  const n = Math.floor(rnd() * 6)
+  for (let k = 0; k < n; k++) args.push(mkValue(0))
+  diff(
+    "twJoin",
+    JSON.stringify(args, bigintReplacer),
+    refTwJoin(...args),
+    twJoin(...args)
+  )
+}
+
+// ---------- 3. clsx/lite (cn) vs clsx/lite (reference) ----------------------
+// clsx/lite ignores everything but strings and falsy values by contract.
+for (let i = 0; i < ITERS; i++) {
+  const args = []
+  const n = Math.floor(rnd() * 6)
+  for (let k = 0; k < n; k++) args.push(mkStringlyValue())
+  diff(
+    "clsx-lite",
+    JSON.stringify(args, bigintReplacer),
+    refLite(...args),
+    liteClsx(...args)
+  )
+}
+
+// ---------- 4. hand cases -----------------------------------------------------
+hand(
+  "twJoin array-like",
+  twJoin({ length: 2, 0: "p-4", 1: "m-2" }),
+  refTwJoin({ length: 2, 0: "p-4", 1: "m-2" })
+)
+hand(
+  "twJoin nested array-like",
+  twJoin(["a", { length: 1, 0: "b" }]),
+  refTwJoin(["a", { length: 1, 0: "b" }])
+)
+hand(
+  "clsx array-like is a dict",
+  clsx({ length: 2, 0: "p-4", 1: "m-2" }),
+  refClsx({ length: 2, 0: "p-4", 1: "m-2" })
+)
+hand(
+  "clsx function",
+  clsx(() => {}),
+  refClsx(() => {})
+)
+hand(
+  "twJoin function",
+  twJoin(() => {}),
+  refTwJoin(() => {})
+)
+
+console.log(`join: pass ${pass}  fail ${fail}`)
+for (const r of report) {
+  console.log(`DIFF [${r.label}] args=${r.args}`)
+  console.log(`     ref = ${JSON.stringify(r.expected)}`)
+  console.log(`     cn  = ${JSON.stringify(r.actual)}`)
+}
+process.exit(fail > 0 ? 1 : 0)


### PR DESCRIPTION
Fixes a claim-table hang and silent class drops in the engine for wide custom conflict groups and large merges, makes `cn build --content` honor brace globs, named dot/ignored directories, symlinks, and long tokens, and matches tailwind-merge on Unicode whitespace separators and `twJoin` array-likes, with new differential suites for each.