### PR TITLE
fix: accept single extension definitions

### DIFF
--- a/.changeset/extend-single-definition.md
+++ b/.changeset/extend-single-definition.md
@@ -1,0 +1,5 @@
+---
+"cn": patch
+---
+
+Accept a single class or theme definition in an extension instead of throwing.

--- a/packages/cn/src/compiler.ts
+++ b/packages/cn/src/compiler.ts
@@ -127,7 +127,7 @@ export const mergeConfigs = (
     if (!src) return
     for (const key in src) {
       const add = src[key]
-      if (add) target[key] = target[key] ? [...target[key], ...add] : [...add]
+      if (add) target[key] = (target[key] ?? []).concat(add)
     }
   }
   const ex = extension.extend

--- a/packages/conformance/tests/custom-config.mjs
+++ b/packages/conformance/tests/custom-config.mjs
@@ -247,6 +247,25 @@ const compare = (label, ours, theirs, cases) => {
   )
 }
 
+// 12. extend with a single class definition instead of an array
+{
+  const ext = {
+    extend: {
+      classGroups: { "border-w": { border: ["hairline"] } },
+      theme: { text: "huge" },
+    },
+  }
+  compare("extend-single-definition", createCn(ext), extendTailwindMerge(ext), [
+    "border-hairline border-2",
+    "border-2 border-hairline",
+    "border-hairline border-hairline",
+    "border-hairline border-x-2",
+    "text-huge text-lg",
+    "text-lg text-huge",
+    "text-huge text-[#333]",
+  ])
+}
+
 console.log(`custom-config: pass ${pass}  fail ${fail}`)
 for (const r of report) {
   console.log(`DIFF [${r.label}] input=${JSON.stringify(r.input)}`)


### PR DESCRIPTION
## Summary

- use concat when extension definitions are merged
- treat one class or theme definition as one entry
- compare the new cases with tailwind-merge

This uses the reproduction and proposed concat behavior from @kachkaev.

Closes #15

## Performance

Measured on an Apple M5 Max with Node 25.8.2. The hot-path A/B run used seven alternating process pairs per workload. Each worker used the best of five timed blocks. A lower branch/main ratio is faster.

| Workload | Branch/main |
| --- | ---: |
| Short, cached | 1.01x |
| Long, cached | 1.03x |
| Arbitrary, cold | 1.05x |
| Repeated call | 1.01x |
| SSR-like | 0.97x |
| 8k working set | 0.97x |

The default cn, engine, and table JavaScript files are byte-for-byte equal to main. The hot-path spread is measurement noise.

The changed config-merge path used 21 alternating samples with 10,000 merges per sample and a normal array extension:

| Version | Median |
| --- | ---: |
| main | 37.08 us/op |
| branch | 36.90 us/op |
| branch/main | 0.994x |

No performance regression was found. The new single-definition path cannot run on main because main throws before it completes.

## Test plan

- pnpm run format:check
- pnpm run typecheck
- pnpm run lint
- pnpm run test
- pnpm run size