### PR TITLE
fix: accept readonly config extension arrays

### DIFF
--- a/.changeset/readonly-config-arrays.md
+++ b/.changeset/readonly-config-arrays.md
@@ -1,0 +1,6 @@
+---
+"cn": patch
+---
+
+Accept readonly arrays in config extensions. This lets token tuples declared
+with `as const` work without a defensive copy.

--- a/packages/cn/scripts/check-dts.mjs
+++ b/packages/cn/scripts/check-dts.mjs
@@ -66,6 +66,9 @@ wrapClsx(engine.mergeString)("p-2", ["p-4"])
 
 // config: custom-config surface
 const config: CnConfig = defaultConfig()
+config.theme.font.push("custom")
+config.classGroups["font-family"].push("custom")
+config.orderSensitiveModifiers.push("custom")
 const ext: ConfigExtension = {
   extend: { classGroups: { "font-size": [{ text: ["hero"] }] } },
 }
@@ -73,6 +76,13 @@ const merged: CnConfig = mergeConfigs(config, ext)
 const input: CreateCnInput = ext
 createCn(input)("p-2")
 createCn((c: CnConfig) => c)("p-2")
+const readonlyFontTokens = ["body", "diagram", "headline"] as const
+createCn({
+  extend: {
+    theme: { font: readonlyFontTokens },
+    classGroups: { "font-family": [{ font: readonlyFontTokens }] },
+  },
+})("font-body font-headline")
 createTwMerge(ext)("p-2 p-4")
 extendTailwindMerge(ext)("p-2 p-4")
 const themeRef: { $t: string } = fromTheme("spacing")

--- a/packages/cn/src/compiler.ts
+++ b/packages/cn/src/compiler.ts
@@ -19,7 +19,7 @@ export type ClassGroupDef =
   | { $v: string }
   | { $t: string }
   | ((value: string) => boolean)
-  | { [key: string]: ClassGroupDef[] }
+  | { [key: string]: readonly ClassGroupDef[] }
 
 export interface CnConfig {
   theme: Record<string, ClassGroupDef[]>
@@ -31,29 +31,19 @@ export interface CnConfig {
   prefix?: string
 }
 
+type ConfigExtensionGroups = {
+  theme: Record<string, readonly ClassGroupDef[]>
+  classGroups: Record<string, readonly ClassGroupDef[]>
+  conflictingClassGroups: Record<string, readonly string[]>
+  conflictingClassGroupModifiers: Record<string, readonly string[]>
+  orderSensitiveModifiers: readonly string[]
+}
+
 export interface ConfigExtension {
   prefix?: string
   cacheSize?: number
-  override?: Partial<
-    Pick<
-      CnConfig,
-      | "theme"
-      | "classGroups"
-      | "conflictingClassGroups"
-      | "conflictingClassGroupModifiers"
-      | "orderSensitiveModifiers"
-    >
-  >
-  extend?: Partial<
-    Pick<
-      CnConfig,
-      | "theme"
-      | "classGroups"
-      | "conflictingClassGroups"
-      | "conflictingClassGroupModifiers"
-      | "orderSensitiveModifiers"
-    >
-  >
+  override?: Partial<ConfigExtensionGroups>
+  extend?: Partial<ConfigExtensionGroups>
 }
 
 /**
@@ -101,10 +91,13 @@ export const mergeConfigs = (
   const config = cloneConfig(base)
   if (extension.prefix !== undefined) config.prefix = extension.prefix
 
-  const overrideProps = <T extends object>(target: T, src?: Partial<T>) => {
+  const overrideProps = <V>(
+    target: Record<string, V>,
+    src?: Record<string, V>
+  ) => {
     if (!src) return
     for (const key in src) {
-      if (src[key] !== undefined) target[key] = src[key] as T[typeof key]
+      if (src[key] !== undefined) target[key] = src[key]
     }
   }
   const ov = extension.override
@@ -139,10 +132,7 @@ export const mergeConfigs = (
       ]
     }
     extendArrays(config.theme, ex.theme)
-    extendArrays(
-      config.classGroups as Record<string, readonly ClassGroupDef[]>,
-      ex.classGroups
-    )
+    extendArrays(config.classGroups, ex.classGroups)
     extendArrays(config.conflictingClassGroups, ex.conflictingClassGroups)
     extendArrays(
       config.conflictingClassGroupModifiers,
@@ -259,7 +249,7 @@ const newPartNode = (): PartNode => ({
   lit: [],
 })
 
-const expandTheme = (config: CnConfig, key: string): ClassGroupDef[] =>
+const expandTheme = (config: CnConfig, key: string): readonly ClassGroupDef[] =>
   config.theme[key] ?? []
 
 const buildPartTrie = (
@@ -309,7 +299,7 @@ const buildPartTrie = (
       return
     }
     for (const [key, value] of Object.entries(
-      def as { [key: string]: ClassGroupDef[] }
+      def as { [key: string]: readonly ClassGroupDef[] }
     )) {
       const child = getPart(node, key)
       for (const inner of value) process(inner, child, gid)


### PR DESCRIPTION
## Summary

- accept readonly arrays in extension theme and class-group definitions
- keep CnConfig arrays mutable for callers
- test as-const tuples through the built ESM and CJS declarations

This uses the reproduction and input-only type direction from @kachkaev.

Closes #14

## Performance

Measured on an Apple M5 Max with Node 25.8.2. The A/B run used seven alternating process pairs per workload. Each worker used the best of five timed blocks. A lower branch/main ratio is faster.

| Workload | Branch/main |
| --- | ---: |
| Short, cached | 1.01x |
| Long, cached | 1.04x |
| Arbitrary, cold | 1.03x |
| Repeated call | 1.01x |
| SSR-like | 1.02x |
| 8k working set | 0.98x |

All emitted JavaScript files are byte-for-byte equal to main. The 0.98x to 1.04x spread is measurement noise. This change has no runtime performance effect.

## Test plan

- pnpm run format:check
- pnpm run typecheck
- pnpm run lint
- pnpm run test
- pnpm run size