### PR TITLE
feat: add fast cva variant resolver

### DIFF
--- a/.changeset/fast-cva-port.md
+++ b/.changeset/fast-cva-port.md
@@ -1,0 +1,7 @@
+---
+"cn": minor
+---
+
+Add a `cva` implementation compatible with `class-variance-authority` 0.7.1.
+Export it from `cn` and the smaller `cn/cva` entry with its public types. Also
+export `cx` as an alias for `clsx`.

--- a/README.md
+++ b/README.md
@@ -151,6 +151,33 @@ Custom validator functions work as-is. `fromTheme`, `validators`,
 `mergeConfigs`, and `defaultConfig` are exported from `cn/config`. Tailwind
 v4 prefixes are supported: `createCn({ prefix: "tw" })`.
 
+## Coming from class-variance-authority
+
+Import `cva`, `cx`, and `VariantProps` from `cn`:
+
+```ts
+import { cva, type VariantProps } from "cn"
+
+const button = cva("rounded font-medium", {
+  variants: {
+    intent: {
+      primary: "bg-blue-600 text-white",
+      secondary: "bg-gray-100 text-gray-900",
+    },
+    size: { small: "px-2 py-1", large: "px-4 py-2" },
+  },
+  defaultVariants: { intent: "primary", size: "small" },
+})
+
+type ButtonProps = VariantProps<typeof button>
+```
+
+If you only use the variant API, import the same exports from `cn/cva`. This
+keeps the Tailwind merge engine out of that bundle.
+
+The output and public types match `class-variance-authority` 0.7.1 for normal
+plain-object props. Keep the configuration unchanged after the first call.
+
 ## Coming from tailwind-merge
 
 `cn` produces the same output as tailwind-merge for every input. We verify
@@ -182,13 +209,15 @@ Every export maps to the same name or a familiar one:
 
 ## API
 
-- **`cn`**: `cn(...inputs)`, `twMerge(...)`, `twJoin(...)`, `clsx(...)`
+- **`cn`**: `cn(...)`, `cva(...)`, `twMerge(...)`, `twJoin(...)`, `clsx(...)`,
+  `cx(...)`
 - **`cn/config`**: `createCn(ext?)`, `extendTailwindMerge(ext?)`,
   `createTwMerge(ext?)`, `fromTheme`, `validators`, `defaultConfig()`,
   `mergeConfigs(base, ext)`
 - **`cn/engine`**: `createCn(tables, ...)`, `createEngine(tables, ...)` for
   build-time compiled tables
 - **`cn/lite`**: `clsx(...)`, strings-only join (`clsx/lite` parity)
+- **`cn/cva`**: `cva(...)` and its public types, without the merge engine
 - **CLI**: `npx cn build --help`
 
 ## Credits
@@ -202,5 +231,8 @@ Every export maps to the same name or a familiar one:
   [clsx](https://github.com/lukeed/clsx) by Luke Edwards (MIT licensed).
 - The argument-identity cache for repeated variadic calls re-implements an optimization pioneered by
   [cnfast](https://github.com/aidenybai/cnfast) by Aiden Bai (MIT licensed).
+- The `cva` implementation is ported from
+  [cnfast](https://github.com/aidenybai/cnfast) and matches the public API of
+  [class-variance-authority](https://github.com/joe-bell/cva) 0.7.1 (Apache-2.0 licensed).
 
 Thank you to all three authors.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "pnpm --filter cn run build && pnpm --filter conformance run test",
     "test:src": "pnpm --filter conformance run test:src",
     "bench": "pnpm --filter conformance run bench",
+    "bench:cva": "pnpm --filter conformance run bench:cva",
     "bench:corpus": "pnpm --filter conformance run bench:corpus",
     "size": "pnpm --filter conformance run size",
     "vendor-config": "pnpm --filter conformance run vendor-config",

--- a/packages/cn/package.json
+++ b/packages/cn/package.json
@@ -70,6 +70,16 @@
         "types": "./dist/lite.d.cts",
         "default": "./dist/lite.cjs"
       }
+    },
+    "./cva": {
+      "import": {
+        "types": "./dist/cva.d.ts",
+        "default": "./dist/cva.js"
+      },
+      "require": {
+        "types": "./dist/cva.d.cts",
+        "default": "./dist/cva.cjs"
+      }
     }
   },
   "main": "./dist/index.cjs",

--- a/packages/cn/scripts/check-dts.mjs
+++ b/packages/cn/scripts/check-dts.mjs
@@ -22,9 +22,12 @@ const pkgRoot = fileURLToPath(new URL("..", import.meta.url))
 // README documents. Adding an export? Add it here so the gate covers it.
 const fixture = `
 import {
-  cn, twMerge, clsx, createEngine, twJoin,
+  cn, twMerge, clsx, cx, cva, createEngine, twJoin,
   type ClassArray, type ClassDictionary, type ClassNameArray,
   type ClassNameValue, type ClassValue, type CnConfig, type CnFunction,
+  type ClassProp, type ClassPropKey, type CvaConfig, type CvaProps,
+  type CxOptions, type CxReturn, type OmitUndefined, type StringToBoolean,
+  type VariantProps, type VariantSchema,
   type ConfigExtension, type CreateCnInput, type Engine, type EngineOptions,
   type Tables, type ValidatorImpls,
 } from "cn"
@@ -43,6 +46,10 @@ import {
   type CompileStats, type CompiledTables, type EmitOptions, type SubsetResult,
 } from "cn/compiler"
 import liteDefault, { clsx as liteClsx } from "cn/lite"
+import {
+  cva as subpathCva,
+  type VariantProps as SubpathVariantProps,
+} from "cn/cva"
 
 // clsx-style variadic signatures (0.2.1 published lite's clsx as \`(): string\`)
 const sigs: ((...inputs: ClassValue[]) => string)[] = [
@@ -51,6 +58,7 @@ const sigs: ((...inputs: ClassValue[]) => string)[] = [
 void sigs
 cn("p-2", ["p-4", { "text-sm": true }], undefined, 0, false && "x")
 liteClsx("a", false && "b", ["c"], null)
+cx("a", { b: true })
 twMerge("p-2 p-4", ["px-1", ["px-2"]])
 twJoin("a", ["b"], undefined)
 void engineTwJoin("a")
@@ -90,6 +98,33 @@ const marker: { readonly $v: "isNumber" } = validators.isNumber
 const groupId: DefaultClassGroupIds = "aspect"
 const themeId: DefaultThemeGroupIds = "spacing"
 void [themeRef, marker, groupId, themeId]
+
+// cva: class-variance-authority-compatible values and types
+const button = cva("button", {
+  variants: {
+    size: { small: "text-sm", large: "text-lg" },
+    disabled: { true: "opacity-50", false: null },
+  },
+  defaultVariants: { size: "small", disabled: false },
+})
+const subpathButton = subpathCva("button", {
+  variants: { size: { small: "text-sm", large: "text-lg" } },
+})
+const subpathButtonProps: SubpathVariantProps<typeof subpathButton> = {
+  size: "small",
+}
+subpathButton(subpathButtonProps)
+type ButtonProps = VariantProps<typeof button>
+const buttonProps: ButtonProps = { size: "large", disabled: true }
+button(buttonProps)
+// @ts-expect-error class and className are mutually exclusive
+button({ class: "px-2", className: "py-2" })
+type PublicCvaTypes = [
+  ClassProp, ClassPropKey, CvaConfig<VariantSchema>, CvaProps<VariantSchema>,
+  CxOptions, CxReturn, OmitUndefined<string | undefined>,
+  StringToBoolean<"true">, VariantSchema,
+]
+void (0 as unknown as PublicCvaTypes)
 
 // compiler
 const compiled: CompiledTables = compileToTables(merged)

--- a/packages/cn/src/cva.ts
+++ b/packages/cn/src/cva.ts
@@ -1,0 +1,652 @@
+import type { clsx } from "./engine.js"
+import type { ClassValue } from "./types.js"
+
+const CVA_MEMO_ROW_COUNT = 16
+const CVA_MEMO_NARROW_ROW_COUNT = 8
+const CVA_MEMO_VALUE_SLOTS_PER_ROW = 16
+const CVA_TABLE_MAX_SLOTS = 256
+const CVA_MEMO_LANE_NONE = 0
+const CVA_MEMO_LANE_FAST = 1
+const CVA_MEMO_LANE_WIDE = 2
+const CVA_MEMO_FAST_LANE_MAX_PROP_NAMES = 2
+const CVA_MEMO_FAST_LANE_SLOTS_PER_ROW = 4
+
+const createFilledArray = <T>(count: number, value: T): T[] => {
+  const slots: T[] = []
+  for (let index = 0; index < count; index++) slots.push(value)
+  return slots
+}
+
+const isArray = Array.isArray
+
+const resolveClassValue = (value: ClassValue): string => {
+  if (!value) return ""
+  if (typeof value === "string") return value
+  if (typeof value === "number") return "" + value
+
+  let classList = ""
+  if (isArray(value)) {
+    const length = value.length
+    for (let index = 0; index < length; index++) {
+      const classValue = value[index]
+      if (!classValue) continue
+      const resolvedClassName =
+        typeof classValue === "string"
+          ? classValue
+          : resolveClassValue(classValue)
+      if (resolvedClassName) {
+        if (classList) classList += " "
+        classList += resolvedClassName
+      }
+    }
+    return classList
+  }
+  if (typeof value === "object") {
+    for (const key in value) {
+      if (value[key]) {
+        if (classList) classList += " "
+        classList += key
+      }
+    }
+  }
+  return classList
+}
+
+export type ClassPropKey = "class" | "className"
+
+export type ClassProp =
+  | { class: ClassValue; className?: never }
+  | { class?: never; className: ClassValue }
+  | { class?: never; className?: never }
+
+export type OmitUndefined<T> = T extends undefined ? never : T
+
+export type StringToBoolean<T> = T extends "true" | "false" ? boolean : T
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- intentional class-variance-authority type parity
+export type VariantProps<Component extends (...args: any) => any> = Omit<
+  OmitUndefined<Parameters<Component>[0]>,
+  ClassPropKey
+>
+
+export type CxOptions = Parameters<typeof clsx>
+export type CxReturn = ReturnType<typeof clsx>
+
+export type VariantSchema = Record<string, Record<string, ClassValue>>
+
+type SchemaVariants<T extends VariantSchema> = {
+  [Variant in keyof T]?: StringToBoolean<keyof T[Variant]> | null | undefined
+}
+
+type SchemaVariantsMulti<T extends VariantSchema> = {
+  [Variant in keyof T]?:
+    | StringToBoolean<keyof T[Variant]>
+    | StringToBoolean<keyof T[Variant]>[]
+    | undefined
+}
+
+export type CvaConfig<T> = T extends VariantSchema
+  ? {
+      variants?: T
+      defaultVariants?: SchemaVariants<T>
+      compoundVariants?: (T extends VariantSchema
+        ? (SchemaVariants<T> | SchemaVariantsMulti<T>) & ClassProp
+        : ClassProp)[]
+    }
+  : never
+
+export type CvaProps<T> = T extends VariantSchema
+  ? SchemaVariants<T> & ClassProp
+  : ClassProp
+
+interface RuntimeCvaProps {
+  [propName: string]: unknown
+  class?: ClassValue
+  className?: ClassValue
+}
+
+interface RuntimeCvaConfig {
+  variants?: Record<string, Record<string, ClassValue>>
+  defaultVariants?: Record<string, unknown>
+  compoundVariants?: RuntimeCvaProps[]
+}
+
+interface CompiledCompoundVariant {
+  selectorKeys: string[]
+  selectorValues: unknown[]
+  selectorArrays: (unknown[] | null)[]
+  classNameFragment: string
+}
+
+interface CompiledCombinationTable {
+  slotCount: number
+  statesByKey: Record<string, number>[]
+  stateCounts: number[]
+  defaultStates: number[]
+}
+
+interface CompiledCvaConfig {
+  baseFragment: string
+  variantNames: string[]
+  variantClassNamesByKey: Record<string, string | undefined>[]
+  variantDefinitions: Record<string, ClassValue>[]
+  defaultVariantKeys: unknown[]
+  compiledCompoundVariants: CompiledCompoundVariant[]
+  compoundDefaultValues: Record<string, unknown>
+  memoPropNames: string[]
+  defaultClassName: string | null
+  memoLane: number
+  memoPropName0: string
+  memoPropName1: string
+  memoValueCountPerRow: number
+  memoCandidateValues: unknown[]
+  memoizedValues: unknown[]
+  memoizedResults: string[]
+  memoRingRowCount: number
+  memoWrittenRowCount: number
+  memoScanRowCount: number
+  nextMemoRowIndex: number
+  didMemoHitThisPass: boolean
+  combinationSlotCount: number
+  combinationStatesByKey: Record<string, number>[]
+  combinationStateCounts: number[]
+  combinationDefaultStates: number[]
+  combinationClassNames: (string | null)[]
+}
+
+const normalizeVariantKey = (value: unknown): unknown =>
+  typeof value === "boolean"
+    ? value
+      ? "true"
+      : "false"
+    : value === 0
+      ? "0"
+      : value
+
+const compileCompoundVariant = (
+  compoundVariant: RuntimeCvaProps
+): CompiledCompoundVariant => {
+  const selectorKeys: string[] = []
+  const selectorValues: unknown[] = []
+  const selectorArrays: (unknown[] | null)[] = []
+  for (const selectorKey of Object.keys(compoundVariant)) {
+    if (selectorKey === "class" || selectorKey === "className") continue
+    const selectorValue = compoundVariant[selectorKey]
+    selectorKeys.push(selectorKey)
+    selectorValues.push(selectorValue)
+    selectorArrays.push(Array.isArray(selectorValue) ? selectorValue : null)
+  }
+  const classFragment = resolveClassValue(compoundVariant.class)
+  const classNameFragment = resolveClassValue(compoundVariant.className)
+  const combinedClassNameFragment =
+    classFragment && classNameFragment
+      ? classFragment + " " + classNameFragment
+      : classFragment || classNameFragment
+  return {
+    selectorKeys,
+    selectorValues,
+    selectorArrays,
+    classNameFragment: combinedClassNameFragment,
+  }
+}
+
+const compileCombinationTable = (
+  variantNames: string[],
+  variantClassNamesByKey: Record<string, string | undefined>[],
+  defaultVariantKeys: unknown[]
+): CompiledCombinationTable | null => {
+  const variantStatesByKey: Record<string, number>[] = []
+  const variantStateCounts: number[] = []
+  const defaultVariantStates: number[] = []
+  let combinationSlotCount = 1
+  for (
+    let variantIndex = 0;
+    variantIndex < variantNames.length;
+    variantIndex++
+  ) {
+    const defaultVariantKey = defaultVariantKeys[variantIndex]
+    if (
+      defaultVariantKey !== null &&
+      (typeof defaultVariantKey === "object" ||
+        typeof defaultVariantKey === "symbol" ||
+        typeof defaultVariantKey === "function")
+    ) {
+      return null
+    }
+    const stateByKey: Record<string, number> = Object.create(null)
+    let stateCount = 1
+    for (const valueKey of Object.keys(variantClassNamesByKey[variantIndex]!)) {
+      stateByKey[valueKey] = stateCount++
+    }
+    const defaultVariantKeyString = String(defaultVariantKey)
+    if (stateByKey[defaultVariantKeyString] === undefined) {
+      stateByKey[defaultVariantKeyString] = stateCount++
+    }
+    variantStatesByKey.push(stateByKey)
+    variantStateCounts.push(stateCount)
+    defaultVariantStates.push(stateByKey[defaultVariantKeyString]!)
+    combinationSlotCount *= stateCount
+    if (combinationSlotCount > CVA_TABLE_MAX_SLOTS) return null
+  }
+  return {
+    slotCount: combinationSlotCount,
+    statesByKey: variantStatesByKey,
+    stateCounts: variantStateCounts,
+    defaultStates: defaultVariantStates,
+  }
+}
+
+const compileCvaConfig = (
+  base: ClassValue,
+  config: RuntimeCvaConfig | null | undefined
+): CompiledCvaConfig => {
+  const baseFragment = resolveClassValue(base)
+  const variants = config?.variants
+  const variantNames = variants == null ? [] : Object.keys(variants)
+  const variantClassNamesByKey: Record<string, string | undefined>[] = []
+  const variantDefinitions: Record<string, ClassValue>[] = []
+  const defaultVariantKeys: unknown[] = []
+  const defaultVariants = config?.defaultVariants
+  for (const variantName of variantNames) {
+    const variantDefinition = variants![variantName]!
+    const classNamesByKey: Record<string, string | undefined> =
+      Object.create(null)
+    for (const valueKey of Object.keys(variantDefinition)) {
+      classNamesByKey[valueKey] = resolveClassValue(variantDefinition[valueKey])
+    }
+    variantClassNamesByKey.push(classNamesByKey)
+    variantDefinitions.push(variantDefinition)
+    defaultVariantKeys.push(normalizeVariantKey(defaultVariants?.[variantName]))
+  }
+
+  const compiledCompoundVariants: CompiledCompoundVariant[] = []
+  if (variants != null && config?.compoundVariants) {
+    for (const compoundVariant of config.compoundVariants) {
+      compiledCompoundVariants.push(compileCompoundVariant(compoundVariant))
+    }
+  }
+
+  const compoundDefaultValues: Record<string, unknown> = { ...defaultVariants }
+
+  const memoPropNames: string[] = []
+  const seenMemoPropNames: Record<string, boolean> = Object.create(null)
+  for (const variantName of variantNames) {
+    seenMemoPropNames[variantName] = true
+    memoPropNames.push(variantName)
+  }
+  for (const compiledCompoundVariant of compiledCompoundVariants) {
+    for (const selectorKey of compiledCompoundVariant.selectorKeys) {
+      if (seenMemoPropNames[selectorKey]) continue
+      seenMemoPropNames[selectorKey] = true
+      memoPropNames.push(selectorKey)
+    }
+  }
+
+  const memoPropCount = memoPropNames.length
+  const naturalMemoValueCountPerRow = memoPropCount + 2
+  const isMemoizable =
+    naturalMemoValueCountPerRow <= CVA_MEMO_VALUE_SLOTS_PER_ROW
+  const isFastLane =
+    isMemoizable && memoPropCount <= CVA_MEMO_FAST_LANE_MAX_PROP_NAMES
+  const memoValueCountPerRow = isFastLane
+    ? CVA_MEMO_FAST_LANE_SLOTS_PER_ROW
+    : naturalMemoValueCountPerRow
+  const combinationTable =
+    compiledCompoundVariants.length === 0 && isMemoizable
+      ? compileCombinationTable(
+          variantNames,
+          variantClassNamesByKey,
+          defaultVariantKeys
+        )
+      : null
+
+  return {
+    baseFragment,
+    variantNames,
+    variantClassNamesByKey,
+    variantDefinitions,
+    defaultVariantKeys,
+    compiledCompoundVariants,
+    compoundDefaultValues,
+    memoPropNames,
+    defaultClassName: null,
+    memoLane: isFastLane
+      ? CVA_MEMO_LANE_FAST
+      : isMemoizable
+        ? CVA_MEMO_LANE_WIDE
+        : CVA_MEMO_LANE_NONE,
+    memoPropName0: memoPropNames[0] ?? "class",
+    memoPropName1: memoPropNames[1] ?? memoPropNames[0] ?? "class",
+    memoValueCountPerRow: isMemoizable ? memoValueCountPerRow : 0,
+    memoCandidateValues: isMemoizable
+      ? createFilledArray<unknown>(memoValueCountPerRow, undefined)
+      : [],
+    memoizedValues: isMemoizable
+      ? createFilledArray<unknown>(
+          CVA_MEMO_ROW_COUNT * memoValueCountPerRow,
+          undefined
+        )
+      : [],
+    memoizedResults: isMemoizable
+      ? createFilledArray(CVA_MEMO_ROW_COUNT, "")
+      : [],
+    memoRingRowCount: CVA_MEMO_ROW_COUNT,
+    memoWrittenRowCount: 0,
+    memoScanRowCount: 0,
+    nextMemoRowIndex: 0,
+    didMemoHitThisPass: true,
+    combinationSlotCount:
+      combinationTable === null ? 0 : combinationTable.slotCount,
+    combinationStatesByKey:
+      combinationTable === null ? [] : combinationTable.statesByKey,
+    combinationStateCounts:
+      combinationTable === null ? [] : combinationTable.stateCounts,
+    combinationDefaultStates:
+      combinationTable === null ? [] : combinationTable.defaultStates,
+    combinationClassNames:
+      combinationTable === null
+        ? []
+        : createFilledArray<string | null>(combinationTable.slotCount, null),
+  }
+}
+
+const hasOwnPropertyCheck = Object.prototype.hasOwnProperty
+
+const resolveVariantClassName = (
+  compiledConfig: CompiledCvaConfig,
+  props: RuntimeCvaProps | undefined
+): string => {
+  let className = compiledConfig.baseFragment
+
+  const variantNames = compiledConfig.variantNames
+  for (
+    let variantIndex = 0;
+    variantIndex < variantNames.length;
+    variantIndex++
+  ) {
+    const propValue =
+      props === undefined ? undefined : props[variantNames[variantIndex]!]
+    if (propValue === null) continue
+    const normalizedVariantKey = normalizeVariantKey(propValue)
+    const variantKey =
+      normalizedVariantKey || compiledConfig.defaultVariantKeys[variantIndex]
+    let variantClassName =
+      compiledConfig.variantClassNamesByKey[variantIndex]![variantKey as string]
+    if (variantClassName === undefined) {
+      variantClassName = resolveClassValue(
+        compiledConfig.variantDefinitions[variantIndex]![variantKey as string]
+      )
+    }
+    if (variantClassName) {
+      if (className) className += " "
+      className += variantClassName
+    }
+  }
+
+  const compiledCompoundVariants = compiledConfig.compiledCompoundVariants
+  for (
+    let compoundIndex = 0;
+    compoundIndex < compiledCompoundVariants.length;
+    compoundIndex++
+  ) {
+    const compiledCompoundVariant = compiledCompoundVariants[compoundIndex]!
+    const selectorKeys = compiledCompoundVariant.selectorKeys
+    let doesCompoundVariantMatch = true
+    for (
+      let selectorIndex = 0;
+      selectorIndex < selectorKeys.length;
+      selectorIndex++
+    ) {
+      const selectorKey = selectorKeys[selectorIndex]!
+      const selectedValue =
+        props !== undefined &&
+        hasOwnPropertyCheck.call(props, selectorKey) &&
+        props[selectorKey] !== undefined
+          ? props[selectorKey]
+          : compiledConfig.compoundDefaultValues[selectorKey]
+      const selectorArray =
+        compiledCompoundVariant.selectorArrays[selectorIndex]
+      const doesSelectorMatch =
+        selectorArray !== null
+          ? selectorArray.includes(selectedValue)
+          : selectedValue ===
+            compiledCompoundVariant.selectorValues[selectorIndex]
+      if (!doesSelectorMatch) {
+        doesCompoundVariantMatch = false
+        break
+      }
+    }
+    if (doesCompoundVariantMatch && compiledCompoundVariant.classNameFragment) {
+      if (className) className += " "
+      className += compiledCompoundVariant.classNameFragment
+    }
+  }
+
+  if (props !== undefined) {
+    const additionalClass = resolveClassValue(props.class)
+    if (additionalClass) {
+      if (className) className += " "
+      className += additionalClass
+    }
+    const additionalClassName = resolveClassValue(props.className)
+    if (additionalClassName) {
+      if (className) className += " "
+      className += additionalClassName
+    }
+  }
+
+  return className
+}
+
+const resolveMemoMiss = (
+  compiledConfig: CompiledCvaConfig,
+  propRecord: RuntimeCvaProps
+): string => {
+  const memoValueCountPerRow = compiledConfig.memoValueCountPerRow
+  const memoCandidateValues = compiledConfig.memoCandidateValues
+  const resolvedClassName = resolveVariantClassName(compiledConfig, propRecord)
+  let memoValueIndex = 0
+  for (; memoValueIndex < memoValueCountPerRow; memoValueIndex++) {
+    const memoValue = memoCandidateValues[memoValueIndex]
+    if (
+      memoValue !== null &&
+      (typeof memoValue === "object" || typeof memoValue === "function")
+    ) {
+      break
+    }
+  }
+  if (memoValueIndex === memoValueCountPerRow) {
+    const memoizedValues = compiledConfig.memoizedValues
+    const memoRowIndex = compiledConfig.nextMemoRowIndex
+    const rowStartIndex = memoRowIndex * memoValueCountPerRow
+    for (
+      memoValueIndex = 0;
+      memoValueIndex < memoValueCountPerRow;
+      memoValueIndex++
+    ) {
+      memoizedValues[rowStartIndex + memoValueIndex] =
+        memoCandidateValues[memoValueIndex]
+    }
+    compiledConfig.memoizedResults[memoRowIndex] = resolvedClassName
+    let followingMemoRowIndex = memoRowIndex + 1
+    if (memoRowIndex === compiledConfig.memoWrittenRowCount) {
+      compiledConfig.memoWrittenRowCount = followingMemoRowIndex
+      compiledConfig.memoScanRowCount = followingMemoRowIndex
+    }
+    if (followingMemoRowIndex === compiledConfig.memoRingRowCount) {
+      const memoRingRowCount = compiledConfig.didMemoHitThisPass
+        ? CVA_MEMO_ROW_COUNT
+        : CVA_MEMO_NARROW_ROW_COUNT
+      const memoWrittenRowCount = compiledConfig.memoWrittenRowCount
+      compiledConfig.memoRingRowCount = memoRingRowCount
+      compiledConfig.memoScanRowCount =
+        memoWrittenRowCount < memoRingRowCount
+          ? memoWrittenRowCount
+          : memoRingRowCount
+      compiledConfig.didMemoHitThisPass = false
+      followingMemoRowIndex = 0
+    }
+    compiledConfig.nextMemoRowIndex = followingMemoRowIndex
+  }
+  return resolvedClassName
+}
+
+const resolveThroughFastMemo = (
+  compiledConfig: CompiledCvaConfig,
+  propRecord: RuntimeCvaProps
+): string => {
+  const firstMemoValue = propRecord[compiledConfig.memoPropName0]
+  const secondMemoValue = propRecord[compiledConfig.memoPropName1]
+  const additionalClass = propRecord.class
+  const additionalClassName = propRecord.className
+  const memoizedValues = compiledConfig.memoizedValues
+  const memoScanRowCount = compiledConfig.memoScanRowCount
+  for (let rowIndex = 0; rowIndex < memoScanRowCount; rowIndex++) {
+    const rowStartIndex = rowIndex * CVA_MEMO_FAST_LANE_SLOTS_PER_ROW
+    if (
+      firstMemoValue === memoizedValues[rowStartIndex] &&
+      secondMemoValue === memoizedValues[rowStartIndex + 1] &&
+      additionalClass === memoizedValues[rowStartIndex + 2] &&
+      additionalClassName === memoizedValues[rowStartIndex + 3]
+    ) {
+      compiledConfig.didMemoHitThisPass = true
+      return compiledConfig.memoizedResults[rowIndex]!
+    }
+  }
+  const memoCandidateValues = compiledConfig.memoCandidateValues
+  memoCandidateValues[0] = firstMemoValue
+  memoCandidateValues[1] = secondMemoValue
+  memoCandidateValues[2] = additionalClass
+  memoCandidateValues[3] = additionalClassName
+  return resolveMemoMiss(compiledConfig, propRecord)
+}
+
+const resolveThroughWideMemo = (
+  compiledConfig: CompiledCvaConfig,
+  propRecord: RuntimeCvaProps
+): string => {
+  const memoValueCountPerRow = compiledConfig.memoValueCountPerRow
+  const memoPropNames = compiledConfig.memoPropNames
+  const memoPropCount = memoPropNames.length
+  const memoCandidateValues = compiledConfig.memoCandidateValues
+  for (let memoPropIndex = 0; memoPropIndex < memoPropCount; memoPropIndex++) {
+    memoCandidateValues[memoPropIndex] =
+      propRecord[memoPropNames[memoPropIndex]!]
+  }
+  memoCandidateValues[memoPropCount] = propRecord.class
+  memoCandidateValues[memoPropCount + 1] = propRecord.className
+
+  const memoizedValues = compiledConfig.memoizedValues
+  const memoScanRowCount = compiledConfig.memoScanRowCount
+  for (let rowIndex = 0; rowIndex < memoScanRowCount; rowIndex++) {
+    const rowStartIndex = rowIndex * memoValueCountPerRow
+    let memoValueIndex = 0
+    while (
+      memoValueIndex < memoValueCountPerRow &&
+      memoCandidateValues[memoValueIndex] ===
+        memoizedValues[rowStartIndex + memoValueIndex]
+    ) {
+      memoValueIndex++
+    }
+    if (memoValueIndex === memoValueCountPerRow) {
+      compiledConfig.didMemoHitThisPass = true
+      return compiledConfig.memoizedResults[rowIndex]!
+    }
+  }
+
+  return resolveMemoMiss(compiledConfig, propRecord)
+}
+
+const resolveThroughMemo = (
+  compiledConfig: CompiledCvaConfig,
+  propRecord: RuntimeCvaProps
+): string =>
+  compiledConfig.memoLane === CVA_MEMO_LANE_FAST
+    ? resolveThroughFastMemo(compiledConfig, propRecord)
+    : resolveThroughWideMemo(compiledConfig, propRecord)
+
+const resolveThroughCombinationTable = (
+  compiledConfig: CompiledCvaConfig,
+  propRecord: RuntimeCvaProps
+): string => {
+  const additionalClass = propRecord.class
+  const additionalClassName = propRecord.className
+  if (additionalClass !== undefined || additionalClassName !== undefined) {
+    if (
+      (typeof additionalClass === "object" && additionalClass !== null) ||
+      (typeof additionalClassName === "object" && additionalClassName !== null)
+    ) {
+      return resolveVariantClassName(compiledConfig, propRecord)
+    }
+    return resolveThroughMemo(compiledConfig, propRecord)
+  }
+
+  const variantNames = compiledConfig.variantNames
+  const combinationStatesByKey = compiledConfig.combinationStatesByKey
+  const combinationStateCounts = compiledConfig.combinationStateCounts
+  const combinationDefaultStates = compiledConfig.combinationDefaultStates
+  let combinationSlotIndex = 0
+  for (
+    let variantIndex = 0;
+    variantIndex < variantNames.length;
+    variantIndex++
+  ) {
+    const propValue = propRecord[variantNames[variantIndex]!]
+    if (
+      propValue !== null &&
+      (typeof propValue === "object" || typeof propValue === "function")
+    ) {
+      return resolveVariantClassName(compiledConfig, propRecord)
+    }
+    let variantState = 0
+    if (propValue !== null) {
+      const normalizedVariantKey = normalizeVariantKey(propValue)
+      const resolvedState = normalizedVariantKey
+        ? combinationStatesByKey[variantIndex]![normalizedVariantKey as string]
+        : combinationDefaultStates[variantIndex]!
+      if (resolvedState === undefined)
+        return resolveThroughMemo(compiledConfig, propRecord)
+      variantState = resolvedState
+    }
+    combinationSlotIndex =
+      combinationSlotIndex * combinationStateCounts[variantIndex]! +
+      variantState
+  }
+  const internedClassName =
+    compiledConfig.combinationClassNames[combinationSlotIndex]!
+  if (internedClassName !== null) return internedClassName
+  const resolvedClassName = resolveVariantClassName(compiledConfig, propRecord)
+  compiledConfig.combinationClassNames[combinationSlotIndex] = resolvedClassName
+  return resolvedClassName
+}
+
+export const cva = <T>(base?: ClassValue, config?: CvaConfig<T>) => {
+  let compiledConfig: CompiledCvaConfig | null = null
+
+  return (props?: CvaProps<T>): string => {
+    if (compiledConfig === null) {
+      compiledConfig = compileCvaConfig(
+        base,
+        config as RuntimeCvaConfig | null | undefined
+      )
+    }
+    if (props == null) {
+      let defaultClassName = compiledConfig.defaultClassName
+      if (defaultClassName === null) {
+        defaultClassName = resolveVariantClassName(compiledConfig, undefined)
+        compiledConfig.defaultClassName = defaultClassName
+      }
+      return defaultClassName
+    }
+    const propRecord = props as RuntimeCvaProps
+    if (compiledConfig.combinationSlotCount !== 0) {
+      return resolveThroughCombinationTable(compiledConfig, propRecord)
+    }
+    const memoLane = compiledConfig.memoLane
+    if (memoLane === CVA_MEMO_LANE_FAST)
+      return resolveThroughFastMemo(compiledConfig, propRecord)
+    if (memoLane === CVA_MEMO_LANE_WIDE)
+      return resolveThroughWideMemo(compiledConfig, propRecord)
+    return resolveVariantClassName(compiledConfig, propRecord)
+  }
+}

--- a/packages/cn/src/index.ts
+++ b/packages/cn/src/index.ts
@@ -12,7 +12,20 @@ export const cn = /* @__PURE__ */ wrapClsx(instance.mergeString, instance)
 /** tailwind-merge–compatible variadic merge (strings + nested arrays). */
 export const twMerge = instance.merge
 
-export { clsx, createEngine, twJoin }
+export { clsx, clsx as cx, createEngine, twJoin }
+export {
+  cva,
+  type ClassProp,
+  type ClassPropKey,
+  type CvaConfig,
+  type CvaProps,
+  type CxOptions,
+  type CxReturn,
+  type OmitUndefined,
+  type StringToBoolean,
+  type VariantProps,
+  type VariantSchema,
+} from "./cva.js"
 
 // Custom configs live at "cn/config" (createCn, createTwMerge, fromTheme,
 // validators) — a separate entry so the compiler and default-config data

--- a/packages/cn/tsdown.config.ts
+++ b/packages/cn/tsdown.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     config: "src/config.ts",
     compiler: "src/compiler.ts",
     lite: "src/lite.ts",
+    cva: "src/cva.ts",
   },
   format: ["esm", "cjs"],
   dts: true,

--- a/packages/conformance/bench/cva-worker.mjs
+++ b/packages/conformance/bench/cva-worker.mjs
@@ -1,0 +1,266 @@
+import { readFileSync } from "node:fs"
+
+const [, , implName, scenarioName] = process.argv
+
+const target = await import("cn")
+let cva
+if (implName === "cn") cva = target.cva
+else if (implName === "cnfast") cva = (await import("cnfast")).cva
+else if (implName === "reference") {
+  cva = (await import("class-variance-authority")).cva
+} else throw new Error(`unknown implementation: ${implName}`)
+
+const sites = JSON.parse(
+  readFileSync(new URL("./cva/cva-sites.json", import.meta.url), "utf8")
+)
+const datasetCalls = JSON.parse(
+  readFileSync(new URL("./cva/cva-calls.json", import.meta.url), "utf8")
+)
+
+const shadcnButton = {
+  base: "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none",
+  config: {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+      },
+    },
+    defaultVariants: { variant: "default", size: "default" },
+  },
+}
+
+const compoundHeavy = {
+  base: "button font-semibold border rounded",
+  config: {
+    variants: {
+      intent: {
+        primary: "intent--primary",
+        warning: "intent--warning",
+        danger: "intent--danger",
+      },
+      disabled: {
+        true: "is-disabled opacity-50",
+        false: "is-enabled cursor-pointer",
+      },
+      size: {
+        small: "size--small text-sm",
+        medium: "size--medium text-base",
+        large: "size--large text-lg",
+      },
+      m: { 0: "m-0", 1: "m-1" },
+    },
+    compoundVariants: [
+      { intent: "primary", size: "medium", class: "primary-medium uppercase" },
+      {
+        intent: "warning",
+        disabled: false,
+        class: "warning-enabled text-gray-800",
+      },
+      {
+        intent: "warning",
+        disabled: true,
+        class: "warning-disabled text-black",
+      },
+      {
+        intent: ["warning", "danger"],
+        class: "warning-danger !border-red-500",
+      },
+      {
+        intent: ["warning", "danger"],
+        size: "medium",
+        class: "warning-danger-medium",
+      },
+      { disabled: true, size: "small", className: "disabled-small" },
+      { intent: "primary", m: 1, className: "primary-m1" },
+      {
+        intent: "danger",
+        disabled: false,
+        size: "large",
+        class: "danger-enabled-large",
+      },
+      { m: 0, size: "medium", class: "m0-medium" },
+      { intent: "primary", disabled: false, className: "primary-enabled" },
+      { class: "always-on" },
+      { intent: "danger", size: ["small", "large"], class: "danger-extreme" },
+    ],
+    defaultVariants: {
+      m: 0,
+      disabled: false,
+      intent: "primary",
+      size: "medium",
+    },
+  },
+}
+
+const repeatRows = (rows, count) => {
+  const repeated = []
+  for (let pass = 0; pass < count; pass++) repeated.push(...rows)
+  return repeated
+}
+
+const scenarios = {
+  "realistic-fixed": { sites, calls: datasetCalls, shuffled: false },
+  "realistic-shuffled": { sites, calls: datasetCalls, shuffled: true },
+  defaults: {
+    sites,
+    calls: repeatRows(
+      sites.map((_, index) => [index]),
+      5
+    ),
+    shuffled: false,
+  },
+  "shadcn-steady": {
+    sites: [shadcnButton],
+    calls: repeatRows(
+      [
+        [0, { variant: "default", size: "default" }],
+        [0, { variant: "outline", size: "sm", className: "ml-2" }],
+        [0, { variant: "destructive", size: "default" }],
+        [0, { variant: "ghost", size: "lg", className: "w-full" }],
+        [0, {}],
+        [0, { variant: "outline", size: "sm", className: "ml-2" }],
+      ],
+      40
+    ),
+    shuffled: false,
+  },
+  "memo-churn-fixed": { sites: [shadcnButton], calls: [], shuffled: false },
+  "memo-churn-shuffled": { sites: [shadcnButton], calls: [], shuffled: true },
+  "compound-heavy": {
+    sites: [compoundHeavy],
+    calls: repeatRows(
+      [
+        [0, {}],
+        [0, { intent: "warning", size: "large", disabled: true }],
+        [0, { intent: "danger", size: "medium" }],
+        [0, { intent: "primary", m: 1 }],
+        [0, { intent: "warning", disabled: false, className: "adhoc" }],
+        [0, { intent: "danger", size: "small", disabled: true, m: 1 }],
+      ],
+      40
+    ),
+    shuffled: false,
+  },
+  "object-class": { sites: [shadcnButton], calls: [], shuffled: false },
+  composite: { sites, calls: datasetCalls, shuffled: false, compose: true },
+}
+
+let churnIndex = 0
+for (const variant of ["default", "destructive", "outline", "ghost"]) {
+  for (const size of ["default", "sm", "lg"]) {
+    scenarios["memo-churn-fixed"].calls.push([
+      0,
+      { variant, size, className: `churn-${churnIndex++}` },
+    ])
+    scenarios["memo-churn-fixed"].calls.push([0, { variant, size }])
+  }
+}
+scenarios["memo-churn-fixed"].calls = repeatRows(
+  scenarios["memo-churn-fixed"].calls,
+  10
+)
+scenarios["memo-churn-shuffled"].calls = scenarios["memo-churn-fixed"].calls
+for (let index = 0; index < 240; index++) {
+  scenarios["object-class"].calls.push([
+    0,
+    {
+      variant: "outline",
+      size: "sm",
+      className: { [`dynamic-${index % 7}`]: true, hidden: index % 2 === 0 },
+    },
+  ])
+}
+
+if (scenarioName === "creation") {
+  let sink = 0
+  let best = Infinity
+  for (let attempt = 0; attempt < 15; attempt++) {
+    const start = process.hrtime.bigint()
+    for (let index = 0; index < 20_000; index++) {
+      sink += cva(
+        sites[index % sites.length].base,
+        sites[index % sites.length].config ?? undefined
+      ).length
+    }
+    const ns = Number(process.hrtime.bigint() - start) / 20_000
+    if (ns < best) best = ns
+  }
+  console.log(
+    JSON.stringify({
+      impl: implName,
+      scenario: scenarioName,
+      nsPerOp: best,
+      sink: sink % 10,
+    })
+  )
+  process.exit(0)
+}
+
+const scenario = scenarios[scenarioName]
+if (!scenario) throw new Error(`unknown scenario: ${scenarioName}`)
+const instances = scenario.sites.map(({ base, config }) =>
+  cva(base, config ?? undefined)
+)
+const callers = scenario.calls.map((row) => {
+  const instance = instances[row[0]]
+  const props = row.length === 2 ? row[1] : undefined
+  if (scenario.compose) return () => target.cn(instance(props))
+  return () => instance(props)
+})
+
+let randomSeed = 0xc4abe4c
+const random = () => {
+  randomSeed ^= randomSeed << 13
+  randomSeed >>>= 0
+  randomSeed ^= randomSeed >> 17
+  randomSeed ^= randomSeed << 5
+  randomSeed >>>= 0
+  return randomSeed / 0x100000000
+}
+const identity = Array.from({ length: callers.length }, (_, index) => index)
+const orders = [identity]
+if (scenario.shuffled) {
+  orders.length = 0
+  for (let orderIndex = 0; orderIndex < 8; orderIndex++) {
+    const order = [...identity]
+    for (let index = order.length - 1; index > 0; index--) {
+      const other = Math.floor(random() * (index + 1))
+      const value = order[index]
+      order[index] = order[other]
+      order[other] = value
+    }
+    orders.push(order)
+  }
+}
+
+let sink = 0
+const run = (order) => {
+  for (const index of order) sink += callers[index]().length
+}
+for (let warmup = 0; warmup < 30; warmup++) run(orders[warmup % orders.length])
+let best = Infinity
+for (let attempt = 0; attempt < 15; attempt++) {
+  const start = process.hrtime.bigint()
+  for (let iteration = 0; iteration < 40; iteration++)
+    run(orders[iteration % orders.length])
+  const ns = Number(process.hrtime.bigint() - start) / (40 * callers.length)
+  if (ns < best) best = ns
+}
+console.log(
+  JSON.stringify({
+    impl: implName,
+    scenario: scenarioName,
+    nsPerOp: best,
+    sink: sink % 10,
+  })
+)

--- a/packages/conformance/bench/cva.mjs
+++ b/packages/conformance/bench/cva.mjs
@@ -1,0 +1,62 @@
+import { execFileSync } from "node:child_process"
+import { cpus } from "node:os"
+import { fileURLToPath } from "node:url"
+
+const worker = fileURLToPath(new URL("./cva-worker.mjs", import.meta.url))
+const scenarios = [
+  ["creation", "creation"],
+  ["realistic-fixed", "realistic mix, fixed"],
+  ["realistic-shuffled", "realistic mix, shuffled"],
+  ["defaults", "all defaults / zero argument"],
+  ["shadcn-steady", "shadcn steady state"],
+  ["memo-churn-fixed", "memo miss churn, fixed"],
+  ["memo-churn-shuffled", "memo miss churn, shuffled"],
+  ["compound-heavy", "compound heavy"],
+  ["object-class", "mutable object className"],
+  ["composite", "composite cn(cva(props))"],
+]
+const implementations = ["reference", "cnfast", "cn"]
+const format = (ns) =>
+  ns >= 1000 ? `${(ns / 1000).toFixed(2)} us` : `${ns.toFixed(1)} ns`
+
+console.log(
+  "CVA replay against class-variance-authority 0.7.1 and cnfast 0.2.0"
+)
+console.log(
+  `${process.version} on ${process.platform}/${process.arch}; ${cpus()[0]?.model}`
+)
+console.log("48 generated sites, 1,152 realistic calls; best of 15 samples")
+const callRatios = []
+for (const [key, label] of scenarios) {
+  const rows = []
+  for (const implementation of implementations) {
+    const output = execFileSync(
+      process.execPath,
+      [worker, implementation, key],
+      {
+        encoding: "utf8",
+      }
+    )
+    rows.push(JSON.parse(output.trim().split("\n").pop()))
+  }
+  const byName = Object.fromEntries(rows.map((row) => [row.impl, row.nsPerOp]))
+  const speedup = byName.reference / byName.cn
+  const versusCnfast = byName.cnfast / byName.cn
+  if (key !== "creation") callRatios.push([speedup, versusCnfast])
+  console.log(
+    `${label.padEnd(32)} cn ${format(byName.cn).padStart(9)} | ` +
+      `cva ${format(byName.reference).padStart(9)} | ` +
+      `cnfast ${format(byName.cnfast).padStart(9)} | ` +
+      `${speedup.toFixed(2)}x vs cva | ${versusCnfast.toFixed(2)}x vs cnfast`
+  )
+}
+
+const geometricMean = (values) =>
+  Math.exp(
+    values.reduce((sum, value) => sum + Math.log(value), 0) / values.length
+  )
+console.log(
+  `nine call-scenario geometric mean (synthetic): ` +
+    `${geometricMean(callRatios.map(([speedup]) => speedup)).toFixed(2)}x vs cva | ` +
+    `${geometricMean(callRatios.map(([, versusCnfast]) => versusCnfast)).toFixed(2)}x vs cnfast`
+)

--- a/packages/conformance/bench/cva/cva-calls.json
+++ b/packages/conformance/bench/cva/cva-calls.json
@@ -1,0 +1,1848 @@
+[
+  [0, { "size": "ghost", "variant": "primary" }],
+  [1, { "variant": "secondary", "orientation": "secondary" }],
+  [2, { "color": "outline" }],
+  [3, { "variant": "sm" }],
+  [4, {}],
+  [5, { "align": "sm", "color": "sm" }],
+  [6, { "tone": "sm" }],
+  [7, {}],
+  [8, { "align": "primary" }],
+  [9, { "orientation": "outline" }],
+  [10, { "disabled": true }],
+  [11, { "size": "primary" }],
+  [12],
+  [
+    13,
+    {
+      "variant": "ghost",
+      "className": "cn-checkbox peer relative shrink-0 outline-none after:absolute after:-inset-x-3 after:-inset-y-2 disabled:cursor-not-allowed disabled:opacity-50"
+    }
+  ],
+  [14, { "tone": "secondary" }],
+  [15, {}],
+  [16, { "align": "primary", "className": "cn-alert-dialog-header" }],
+  [17, {}],
+  [
+    18,
+    {
+      "active": true,
+      "className": "cn-alert-dialog-content group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 outline-none"
+    }
+  ],
+  [19, { "align": "secondary" }],
+  [20, { "orientation": "primary" }],
+  [
+    21,
+    {
+      "align": "outline",
+      "className": "-mx-1.5 my-1.5 h-px bg-neutral-600 dark:bg-neutral-700"
+    }
+  ],
+  [22, { "variant": "outline" }],
+  [23, { "orientation": "secondary" }],
+  [24, { "side": "primary" }],
+  [25, { "variant": "primary" }],
+  [26, { "side": "default" }],
+  [
+    27,
+    {
+      "size": "primary",
+      "className": "cn-context-menu-sub-trigger flex cursor-default items-center outline-hidden select-none [&_svg]:pointer-events-none [&_svg]:shrink-0"
+    }
+  ],
+  [
+    28,
+    {
+      "size": "md",
+      "className": "[&_[role=gridcell]]:w-[33px] [&_[role=gridcell].bg-accent]:bg-sidebar-primary [&_[role=gridcell].bg-accent]:text-sidebar-primary-foreground"
+    }
+  ],
+  [29, { "side": "secondary", "active": true }],
+  [30, { "selected": true }],
+  [31, { "className": "bg-chart-1 text-chart-5" }],
+  [
+    32,
+    {
+      "className": "absolute inset-0 flex w-(--sidebar-menu-width) bg-transparent"
+    }
+  ],
+  [33, { "align": "default" }],
+  [34],
+  [35, {}],
+  [36, { "orientation": "secondary" }],
+  [37, { "color": "outline" }],
+  [38, { "color": "default", "className": "cn-badge-variant-link" }],
+  [39, { "className": "basis-1/2 pt-1" }],
+  [40, { "side": "default" }],
+  [41, { "orientation": "default" }],
+  [42],
+  [43, { "disabled": false }],
+  [44, { "loading": false }],
+  [45, {}],
+  [46, { "color": "outline" }],
+  [47, {}],
+  [0],
+  [1],
+  [2, { "color": "outline" }],
+  [3, { "variant": "sm" }],
+  [4, {}],
+  [5, { "align": "sm" }],
+  [6, {}],
+  [7, { "className": "cn-button-variant-secondary" }],
+  [8],
+  [9, { "orientation": "outline" }],
+  [10, { "disabled": true }],
+  [11, {}],
+  [12, { "selected": false }],
+  [13, {}],
+  [
+    14,
+    {
+      "className": "absolute bg-primary data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full"
+    }
+  ],
+  [15, {}],
+  [16, { "align": "primary" }],
+  [17, { "tone": "outline" }],
+  [18, { "color": "primary" }],
+  [19, { "align": "default", "className": "bottom-0 translate-y-3/4" }],
+  [20, {}],
+  [
+    21,
+    {
+      "align": "primary",
+      "className": "cn-command flex size-full flex-col overflow-hidden"
+    }
+  ],
+  [22, { "size": "secondary" }],
+  [23, { "orientation": "outline" }],
+  [24, { "side": "primary" }],
+  [25, {}],
+  [
+    26,
+    {
+      "color": "default",
+      "className": "cn-checkbox cn-checkbox-aria peer relative shrink-0 outline-none after:absolute after:-inset-x-3 after:-inset-y-2 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50"
+    }
+  ],
+  [27, {}],
+  [28, { "size": "ghost" }],
+  [
+    29,
+    {
+      "active": false,
+      "className": "absolute right-1 bottom-1 bg-foreground/90 px-1 text-[0.5rem] font-semibold tracking-wider text-background"
+    }
+  ],
+  [30, {}],
+  [31, { "orientation": "secondary" }],
+  [32, {}],
+  [33, { "variant": "sm" }],
+  [34, {}],
+  [35, {}],
+  [36, { "color": "secondary" }],
+  [37, { "color": "outline" }],
+  [38, { "color": "ghost" }],
+  [39, { "className": "absolute top-[38px] left-[30px] z-10 rotate-[-40deg]" }],
+  [40, { "orientation": "secondary" }],
+  [41],
+  [42, { "align": "secondary" }],
+  [43, { "disabled": true, "align": "ghost" }],
+  [
+    44,
+    {
+      "className": "cn-command-input outline-hidden disabled:cursor-not-allowed disabled:opacity-50 [&::-webkit-search-cancel-button]:hidden"
+    }
+  ],
+  [45, {}],
+  [46, { "color": "primary", "align": "outline" }],
+  [47, {}],
+  [0, {}],
+  [1, {}],
+  [2, { "color": "outline" }],
+  [3, { "variant": "sm" }],
+  [4, {}],
+  [5, {}],
+  [6, { "tone": "primary" }],
+  [7, { "size": "ghost", "className": "inset-y-0 -left-12 my-auto" }],
+  [8, { "side": "primary" }],
+  [9, { "orientation": "secondary" }],
+  [10, { "disabled": false }],
+  [11, { "size": "default" }],
+  [12, { "selected": false }],
+  [13, {}],
+  [14, { "tone": "secondary" }],
+  [15, {}],
+  [16, { "color": "default" }],
+  [17, { "tone": "outline" }],
+  [18, { "color": "primary" }],
+  [19, { "align": "ghost" }],
+  [20, {}],
+  [21, { "align": "ghost", "side": "primary" }],
+  [22, {}],
+  [23, { "loading": true }],
+  [24, { "side": "primary" }],
+  [25, { "className": "aspect-auto h-[250px] w-full" }],
+  [26, { "side": "outline" }],
+  [27, { "size": "outline" }],
+  [
+    28,
+    {
+      "size": "primary",
+      "className": "border style-vega:rounded-lg style-vega:p-6 style-nova:rounded-lg style-nova:p-4 style-lyra:rounded-none style-lyra:p-4 style-maia:rounded-xl style-maia:p-6 style-mira:rounded-md style-mira:p-4 style-luma:rounded-xl style-luma:p-6 style-rhea:rounded-xl style-rhea:p-6"
+    }
+  ],
+  [29, { "active": true }],
+  [30, { "selected": false }],
+  [31],
+  [32, {}],
+  [33, { "variant": "sm" }],
+  [
+    34,
+    {
+      "size": "primary",
+      "className": "-top-12 left-1/2 -translate-x-1/2 rotate-90"
+    }
+  ],
+  [35, { "side": "primary" }],
+  [36, {}],
+  [37],
+  [38, { "color": "outline" }],
+  [39, {}],
+  [40, {}],
+  [41, {}],
+  [42],
+  [
+    43,
+    {
+      "disabled": true,
+      "className": "bg-green-600 text-green-50 dark:bg-green-600 dark:text-green-50"
+    }
+  ],
+  [44, {}],
+  [45, { "side": "md" }],
+  [46, { "align": "primary" }],
+  [47, { "tone": "secondary", "className": "block border-b p-4 text-xl" }],
+  [0, { "size": "primary", "variant": "primary" }],
+  [1, { "className": "cn-card group/card flex flex-col" }],
+  [2, {}],
+  [3, { "variant": "sm" }],
+  [4, { "loading": true }],
+  [5, { "align": "default", "color": "sm" }],
+  [6, {}],
+  [7, { "size": "ghost" }],
+  [8, { "align": "primary", "side": "outline" }],
+  [9, { "orientation": "secondary" }],
+  [10],
+  [11, {}],
+  [12, {}],
+  [13, {}],
+  [14, { "tone": "outline" }],
+  [15, {}],
+  [16, {}],
+  [17],
+  [18, { "color": "primary" }],
+  [
+    19,
+    {
+      "align": "secondary",
+      "className": "absolute top-1.5 right-9 z-10 flex items-center"
+    }
+  ],
+  [20, { "className": "cn-attachment-content max-w-full min-w-0 flex-1" }],
+  [21, {}],
+  [
+    22,
+    { "variant": "outline", "className": "top-1/2 -left-12 -translate-y-1/2" }
+  ],
+  [
+    23,
+    {
+      "orientation": "secondary",
+      "loading": false,
+      "className": "-ms-6 translate-x-1 rounded-full transition-all duration-100 ease-linear data-checked:ms-0 data-checked:translate-x-0"
+    }
+  ],
+  [24, { "side": "primary" }],
+  [25],
+  [26],
+  [27, {}],
+  [28, { "size": "md" }],
+  [29, { "side": "outline", "active": true }],
+  [30, { "selected": true }],
+  [
+    31,
+    {
+      "className": "cn-accordion-trigger-icon pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+    }
+  ],
+  [32, { "size": "primary" }],
+  [33, { "variant": "primary", "align": "default" }],
+  [34],
+  [35, { "side": "primary" }],
+  [36, { "color": "primary" }],
+  [
+    37,
+    {
+      "color": "sm",
+      "className": "absolute inset-y-0 right-0 left-54 z-40 bg-transparent"
+    }
+  ],
+  [38, {}],
+  [39, { "className": "[&_.preview]:h-[350px] [&_pre]:h-[350px]!" }],
+  [40, { "side": "sm", "loading": true }],
+  [41, { "orientation": "default", "className": "block truncate font-medium" }],
+  [42, {}],
+  [43, { "disabled": true }],
+  [44],
+  [45, {}],
+  [46, { "color": "outline" }],
+  [47, { "tone": "ghost" }],
+  [0, {}],
+  [1, { "variant": "ghost" }],
+  [2, {}],
+  [3, { "variant": "sm" }],
+  [4, {}],
+  [5, { "color": "default", "className": "animate-none! sm:max-w-md" }],
+  [6, {}],
+  [7, { "size": "ghost" }],
+  [8, { "align": "secondary" }],
+  [9],
+  [10, { "disabled": true }],
+  [11, {}],
+  [12, { "selected": true }],
+  [13, {}],
+  [
+    14,
+    {
+      "tone": "secondary",
+      "className": "cn-context-menu-subcontent cn-menu-target cn-menu-translucent"
+    }
+  ],
+  [
+    15,
+    {
+      "className": "cn-alert-dialog-content group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 outline-none"
+    }
+  ],
+  [16, { "align": "primary" }],
+  [17, { "tone": "default" }],
+  [
+    18,
+    {
+      "color": "primary",
+      "className": "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2"
+    }
+  ],
+  [19, { "align": "ghost" }],
+  [20, { "orientation": "primary" }],
+  [21, { "side": "default" }],
+  [22],
+  [23, { "loading": false }],
+  [24, {}],
+  [25, { "variant": "primary" }],
+  [26, { "color": "primary" }],
+  [27, { "size": "primary" }],
+  [28, { "size": "md", "className": "top-0 -translate-y-3/4" }],
+  [29, { "side": "ghost" }],
+  [30, { "selected": true }],
+  [31],
+  [32, {}],
+  [33, { "className": "icon" }],
+  [34, { "size": "primary" }],
+  [
+    35,
+    {
+      "side": "primary",
+      "className": "-translate-y-2 flex-wrap gap-2 *:basis-1/4 *:justify-center"
+    }
+  ],
+  [36, { "className": "cn-dialog-overlay-aria fixed inset-0 isolate z-50" }],
+  [37, { "color": "primary" }],
+  [38, {}],
+  [
+    39,
+    {
+      "tone": "secondary",
+      "className": "block max-w-full min-w-0 truncate font-medium group-data-[state=processing]/attachment:shimmer group-data-[state=uploading]/attachment:shimmer"
+    }
+  ],
+  [40, { "side": "default" }],
+  [41, {}],
+  [42],
+  [43, { "disabled": true }],
+  [44, { "size": "default", "orientation": "secondary" }],
+  [45, {}],
+  [46, { "color": "primary" }],
+  [47, {}],
+  [
+    0,
+    {
+      "size": "ghost",
+      "variant": "primary",
+      "className": "cn-combobox-chip-input min-w-16 flex-1 outline-none"
+    }
+  ],
+  [1, { "variant": "outline", "orientation": "primary" }],
+  [2, {}],
+  [
+    3,
+    {
+      "className": "cn-command-dialog top-1/3 translate-y-0 overflow-hidden p-0"
+    }
+  ],
+  [4, { "loading": true }],
+  [5],
+  [6],
+  [7, { "size": "ghost" }],
+  [8],
+  [9, { "orientation": "secondary" }],
+  [10, { "disabled": true }],
+  [11, {}],
+  [12, {}],
+  [
+    13,
+    {
+      "variant": "ghost",
+      "className": "cn-attachment group/attachment relative flex max-w-full min-w-0 shrink-0 flex-wrap border bg-card text-card-foreground transition-colors has-[>a,>button]:hover:bg-muted/50 data-[state=error]:border-destructive/30 data-[state=idle]:border-dashed"
+    }
+  ],
+  [14],
+  [15, {}],
+  [16, { "align": "primary", "color": "secondary" }],
+  [
+    17,
+    {
+      "tone": "secondary",
+      "orientation": "secondary",
+      "className": "absolute top-[0px] left-[122px] z-10 text-sm font-medium"
+    }
+  ],
+  [18, { "color": "secondary", "active": true }],
+  [19, { "align": "default" }],
+  [20, { "orientation": "primary" }],
+  [21, { "align": "md", "variant": "secondary" }],
+  [22, { "size": "secondary" }],
+  [23, { "orientation": "secondary" }],
+  [24, { "side": "primary" }],
+  [25, { "variant": "primary" }],
+  [26, { "side": "outline" }],
+  [27, { "size": "secondary" }],
+  [28, { "size": "md" }],
+  [29, { "side": "ghost" }],
+  [30, { "className": "absolute inset-0 bg-muted dark:bg-muted/30" }],
+  [31, { "orientation": "secondary" }],
+  [32, {}],
+  [
+    33,
+    {
+      "align": "default",
+      "className": "appearance-none [&::-webkit-calendar-picker-indicator]:hidden [&::-webkit-calendar-picker-indicator]:appearance-none"
+    }
+  ],
+  [34, { "size": "md" }],
+  [35, {}],
+  [36, { "color": "sm" }],
+  [37, { "color": "primary" }],
+  [38, {}],
+  [39, {}],
+  [40, { "orientation": "outline" }],
+  [41, { "orientation": "ghost" }],
+  [42, { "align": "primary" }],
+  [43, { "disabled": true, "className": "top-1" }],
+  [44, { "loading": false, "orientation": "secondary" }],
+  [45, { "side": "secondary" }],
+  [46, { "color": "outline" }],
+  [47, {}],
+  [0, { "size": "sm", "variant": "primary" }],
+  [1],
+  [2, { "color": "primary", "className": "top-0 -translate-y-3/4" }],
+  [3, { "variant": "secondary" }],
+  [4, { "loading": false }],
+  [5],
+  [6, {}],
+  [7, { "size": "ghost", "className": "animate-pulse text-red-500" }],
+  [8, { "align": "primary" }],
+  [9],
+  [10, { "disabled": true, "align": "primary", "orientation": "outline" }],
+  [11, { "size": "secondary" }],
+  [12, { "selected": true }],
+  [13, {}],
+  [14, { "tone": "secondary" }],
+  [15, {}],
+  [
+    16,
+    {
+      "align": "primary",
+      "color": "ghost",
+      "className": "aspect-video h-12 w-full rounded-lg bg-muted/50"
+    }
+  ],
+  [17, { "tone": "outline" }],
+  [18, { "color": "primary" }],
+  [19, {}],
+  [20, {}],
+  [
+    21,
+    { "align": "secondary", "side": "primary", "className": "cn-command-empty" }
+  ],
+  [22, { "variant": "outline" }],
+  [23, { "orientation": "outline" }],
+  [24, { "side": "primary" }],
+  [25, { "variant": "primary" }],
+  [26, {}],
+  [27, {}],
+  [28, {}],
+  [29, {}],
+  [30, {}],
+  [31, { "orientation": "secondary", "variant": "primary" }],
+  [32, { "size": "primary" }],
+  [33, { "variant": "outline", "align": "default" }],
+  [34, { "size": "md", "align": "primary" }],
+  [35, {}],
+  [
+    36,
+    {
+      "className": "cn-button-group-orientation-vertical flex-col [&>*:not(:first-child)]:rounded-t-none [&>*:not(:first-child)]:border-t-0 [&>*:not(:last-child)]:rounded-b-none"
+    }
+  ],
+  [37, {}],
+  [38, { "className": "block md:hidden" }],
+  [39, {}],
+  [40, { "side": "default" }],
+  [41, { "orientation": "outline" }],
+  [
+    42,
+    {
+      "align": "secondary",
+      "className": "cn-context-menu-content cn-context-menu-content-logical cn-menu-target cn-menu-translucent z-50 max-h-(--available-height) origin-(--transform-origin) overflow-x-hidden overflow-y-auto outline-none"
+    }
+  ],
+  [
+    43,
+    {
+      "disabled": true,
+      "align": "ghost",
+      "className": "cn-breadcrumb-list flex flex-wrap items-center wrap-break-word"
+    }
+  ],
+  [44, { "size": "default" }],
+  [45, {}],
+  [46, { "color": "secondary" }],
+  [47, { "tone": "secondary" }],
+  [0, {}],
+  [1, { "variant": "outline", "orientation": "secondary" }],
+  [2, { "color": "primary" }],
+  [3, { "variant": "outline" }],
+  [4, {}],
+  [5, { "align": "ghost", "color": "primary" }],
+  [6, { "tone": "secondary" }],
+  [7, { "size": "secondary" }],
+  [8, { "align": "outline" }],
+  [
+    9,
+    {
+      "className": "bg-green-50 text-green-700 dark:bg-green-950 dark:text-green-300"
+    }
+  ],
+  [10, {}],
+  [11, { "size": "primary" }],
+  [
+    12,
+    {
+      "selected": true,
+      "className": "absolute inset-y-0 right-0 left-54 z-40 bg-transparent"
+    }
+  ],
+  [13, { "variant": "primary" }],
+  [14, { "tone": "secondary" }],
+  [15, {}],
+  [16],
+  [17, { "orientation": "outline" }],
+  [18, { "color": "secondary", "active": true }],
+  [19, {}],
+  [20, { "orientation": "primary" }],
+  [21, { "className": "cn-button-variant-secondary" }],
+  [22, {}],
+  [23, {}],
+  [24, { "className": "[&>pre]:max-h-96" }],
+  [25, {}],
+  [26, { "side": "outline", "className": "-mt-1 h-[200px]" }],
+  [
+    27,
+    {
+      "size": "outline",
+      "className": "after:absolute after:-inset-2 md:after:hidden"
+    }
+  ],
+  [28, { "size": "ghost" }],
+  [29, { "side": "outline" }],
+  [30, {}],
+  [
+    31,
+    {
+      "orientation": "secondary",
+      "variant": "outline",
+      "className": "cn-attachment-media relative flex aspect-square shrink-0 items-center justify-center overflow-hidden group-data-[state=error]/attachment:bg-destructive/10 group-data-[state=error]/attachment:text-destructive [&_svg]:pointer-events-none"
+    }
+  ],
+  [32, { "size": "primary", "className": "h-8 min-w-8 px-1.5" }],
+  [33, {}],
+  [34, { "size": "outline", "align": "primary" }],
+  [35, { "side": "primary" }],
+  [
+    36,
+    {
+      "color": "primary",
+      "orientation": "sm",
+      "className": "cn-accordion-content h-(--disclosure-panel-height) overflow-clip transition-[height]"
+    }
+  ],
+  [37, { "color": "outline" }],
+  [38, { "color": "default" }],
+  [
+    39,
+    { "tone": "secondary", "className": "bg-transparent [--cell-size:2.1rem]" }
+  ],
+  [40, { "side": "default" }],
+  [41, { "orientation": "ghost" }],
+  [42, {}],
+  [43, { "align": "secondary" }],
+  [
+    44,
+    { "size": "outline", "className": "-mx-1 no-scrollbar overflow-x-hidden" }
+  ],
+  [45, { "side": "ghost", "className": "cn-card-description" }],
+  [
+    46,
+    {
+      "color": "secondary",
+      "align": "primary",
+      "className": "aria-pressed:*:[svg]:stroke-foregfill-foreground aria-pressed:bg-transparent aria-pressed:*:[svg]:fill-foreground"
+    }
+  ],
+  [47, { "tone": "secondary" }],
+  [
+    0,
+    { "size": "sm", "className": "cn-combobox-clear-icon pointer-events-none" }
+  ],
+  [1, { "variant": "secondary" }],
+  [2],
+  [3, {}],
+  [4],
+  [5, { "align": "outline" }],
+  [6, { "tone": "primary" }],
+  [7, { "size": "ghost" }],
+  [8, {}],
+  [9, { "orientation": "secondary" }],
+  [10, { "align": "primary", "orientation": "secondary" }],
+  [11, { "size": "default" }],
+  [12, { "selected": false }],
+  [13, { "variant": "secondary" }],
+  [14, {}],
+  [15, { "className": "border-b px-4 py-3" }],
+  [16, {}],
+  [17, { "tone": "outline" }],
+  [18, {}],
+  [19, { "align": "default" }],
+  [20, {}],
+  [
+    21,
+    {
+      "align": "ghost",
+      "className": "cn-breadcrumb-list flex flex-wrap items-center wrap-break-word"
+    }
+  ],
+  [22, { "size": "outline" }],
+  [23, { "orientation": "secondary" }],
+  [24, {}],
+  [25, {}],
+  [26, { "side": "outline" }],
+  [27],
+  [28, { "className": "cn-breadcrumb" }],
+  [29, { "side": "ghost" }],
+  [30],
+  [31, { "variant": "primary" }],
+  [
+    32,
+    {
+      "size": "ghost",
+      "className": "cn-combobox-clear-icon pointer-events-none"
+    }
+  ],
+  [33, { "variant": "outline" }],
+  [34],
+  [35],
+  [36],
+  [37, {}],
+  [38, { "color": "outline" }],
+  [39, {}],
+  [40, {}],
+  [
+    41,
+    {
+      "orientation": "default",
+      "className": "border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted"
+    }
+  ],
+  [42, { "align": "secondary" }],
+  [
+    43,
+    {
+      "disabled": false,
+      "align": "ghost",
+      "className": "cn-checkbox peer relative shrink-0 outline-none after:absolute after:-inset-x-3 after:-inset-y-2 disabled:cursor-not-allowed disabled:opacity-50"
+    }
+  ],
+  [44, { "size": "default" }],
+  [45, {}],
+  [46, {}],
+  [47, { "tone": "ghost" }],
+  [
+    0,
+    {
+      "className": "absolute top-0 left-[calc(50%-950px-var(--rail-width)-var(--gap))] grid w-(--rail-width) grid-cols-[repeat(2,var(--rail-column))] gap-(--gap) opacity-50 [--rail-column:20rem] [--rail-width:calc(var(--rail-column)*2+var(--gap))]"
+    }
+  ],
+  [1, { "variant": "sm", "className": "border-r-0" }],
+  [2, { "className": "cn-dialog-close" }],
+  [3, { "variant": "outline" }],
+  [4, { "className": "block h-full w-full" }],
+  [5, {}],
+  [6, { "tone": "sm", "loading": true }],
+  [7, { "size": "ghost" }],
+  [8, { "align": "secondary", "side": "primary" }],
+  [9, { "orientation": "secondary" }],
+  [10, { "align": "ghost" }],
+  [11, { "size": "secondary" }],
+  [12, { "className": "cn-bubble-variant-tinted" }],
+  [13, { "variant": "primary", "className": "bg-muted" }],
+  [14, {}],
+  [15, { "className": "absolute inset-0 bg-popover opacity-0" }],
+  [16],
+  [17],
+  [18, { "className": "[&_.preview]:items-start" }],
+  [19, { "align": "secondary" }],
+  [20, { "orientation": "primary", "className": "animate-none! sm:max-w-md" }],
+  [21],
+  [22, { "variant": "outline" }],
+  [23],
+  [24, { "side": "primary", "size": "primary" }],
+  [25, {}],
+  [26, { "side": "default", "color": "primary", "variant": "outline" }],
+  [27, { "size": "outline" }],
+  [28, { "size": "primary" }],
+  [29, { "className": "capitalize data-[state=checked]:opacity-50" }],
+  [30],
+  [31, { "className": "cn-alert-dialog-cancel" }],
+  [32, {}],
+  [33, { "variant": "sm" }],
+  [34, { "className": "h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5" }],
+  [35, { "side": "primary" }],
+  [36, { "color": "secondary" }],
+  [37, { "color": "sm" }],
+  [38, { "color": "ghost" }],
+  [39, { "tone": "secondary" }],
+  [40],
+  [41, { "orientation": "ghost" }],
+  [42, {}],
+  [43, { "disabled": true }],
+  [44, { "loading": true }],
+  [45, {}],
+  [46, { "color": "outline" }],
+  [47, { "tone": "secondary" }],
+  [0, { "size": "primary", "className": "cn-command-input-wrapper" }],
+  [1, {}],
+  [2, { "color": "ghost" }],
+  [
+    3,
+    {
+      "variant": "secondary",
+      "className": "bg-background *:data-[slot=card]:has-[[data-slot=chart]]:shadow-none"
+    }
+  ],
+  [4, {}],
+  [5, { "align": "ghost" }],
+  [6, {}],
+  [7, { "size": "ghost" }],
+  [8],
+  [9, {}],
+  [10, { "disabled": true }],
+  [11],
+  [12, { "selected": true, "className": "**:[.container]:justify-start" }],
+  [13, { "variant": "secondary" }],
+  [14],
+  [15],
+  [16, { "align": "primary" }],
+  [17, { "tone": "outline" }],
+  [18, { "color": "secondary" }],
+  [19, {}],
+  [20, { "orientation": "primary" }],
+  [
+    21,
+    {
+      "align": "ghost",
+      "side": "primary",
+      "className": "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2"
+    }
+  ],
+  [22, {}],
+  [23, { "orientation": "secondary" }],
+  [24, { "size": "primary", "selected": true }],
+  [25, { "className": "bg-green-600 dark:bg-green-800" }],
+  [26, { "color": "default", "variant": "outline" }],
+  [27, { "className": "h-9 px-4 py-2 has-[>svg]:px-3" }],
+  [28],
+  [29, {}],
+  [30],
+  [31, { "orientation": "secondary", "variant": "outline" }],
+  [32, { "size": "ghost" }],
+  [33, { "align": "default" }],
+  [34, { "align": "primary" }],
+  [35, {}],
+  [36, { "color": "secondary", "className": "cn-combobox-clear" }],
+  [37, { "color": "sm" }],
+  [38, { "color": "default" }],
+  [39, { "tone": "ghost" }],
+  [40, { "loading": true }],
+  [41, { "orientation": "ghost" }],
+  [42, { "align": "secondary" }],
+  [43, { "disabled": true }],
+  [44, { "loading": false, "size": "default" }],
+  [45, {}],
+  [
+    46,
+    {
+      "color": "primary",
+      "className": "cn-context-menu-radio-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0"
+    }
+  ],
+  [47, { "tone": "secondary" }],
+  [0, { "size": "sm" }],
+  [1, { "variant": "outline" }],
+  [2, { "color": "outline" }],
+  [3, { "variant": "outline" }],
+  [4],
+  [5, { "align": "sm", "color": "ghost" }],
+  [6, { "tone": "sm" }],
+  [7, { "size": "ghost", "className": "h-8 min-w-8 px-1.5" }],
+  [8, {}],
+  [
+    9,
+    {
+      "className": "bg-green-600 text-green-50 dark:bg-green-600 dark:text-green-50"
+    }
+  ],
+  [10, { "disabled": true, "align": "primary" }],
+  [11, { "size": "secondary" }],
+  [12, { "selected": false }],
+  [13, { "variant": "secondary", "className": "cn-button-variant-link" }],
+  [14, {}],
+  [15, {}],
+  [
+    16,
+    { "align": "primary", "className": "aspect-3/4 h-fit w-fit object-cover" }
+  ],
+  [17, { "className": "border-dashed border-primary" }],
+  [18, { "active": false }],
+  [19, {}],
+  [20, { "orientation": "primary", "className": "block dark:hidden" }],
+  [21, { "side": "outline" }],
+  [22, { "variant": "default" }],
+  [23, { "orientation": "outline", "loading": false }],
+  [24, { "side": "primary", "size": "secondary" }],
+  [25, { "variant": "primary" }],
+  [26, { "side": "outline" }],
+  [27, {}],
+  [28, { "size": "ghost" }],
+  [29, { "active": true }],
+  [30, { "selected": false }],
+  [31, { "orientation": "secondary", "className": "-ml-1" }],
+  [32, {}],
+  [
+    33,
+    {
+      "variant": "primary",
+      "align": "default",
+      "className": "cn-command-input-wrapper"
+    }
+  ],
+  [34, { "size": "md" }],
+  [35, {}],
+  [36, { "className": "animate-none!" }],
+  [37, { "color": "outline" }],
+  [38, { "color": "default", "className": "border-b last:border-b-0" }],
+  [39, { "tone": "secondary" }],
+  [40, { "side": "outline", "loading": true }],
+  [41, { "orientation": "ghost" }],
+  [42, { "align": "primary" }],
+  [43],
+  [44, { "loading": true }],
+  [45, { "side": "md" }],
+  [46, { "color": "secondary", "align": "ghost" }],
+  [47, {}],
+  [0, { "variant": "primary" }],
+  [1, { "variant": "secondary" }],
+  [2, { "color": "outline" }],
+  [3, { "variant": "sm" }],
+  [4, { "loading": false }],
+  [5],
+  [6, { "className": "bg-muted-foreground transition-all duration-300" }],
+  [7, {}],
+  [8, { "align": "outline" }],
+  [9, { "orientation": "outline" }],
+  [10, { "disabled": false }],
+  [
+    11,
+    {
+      "size": "default",
+      "className": "-top-12 left-1/2 -translate-x-1/2 rotate-90"
+    }
+  ],
+  [12, {}],
+  [13, { "className": "**:[.container]:justify-start" }],
+  [14, { "tone": "primary" }],
+  [15, {}],
+  [16, { "align": "primary" }],
+  [17],
+  [18],
+  [19],
+  [20, { "orientation": "primary" }],
+  [21, { "align": "secondary" }],
+  [22, {}],
+  [
+    23,
+    {
+      "loading": false,
+      "className": "cn-card-header group/card-header @container/card-header grid auto-rows-min items-start has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto]"
+    }
+  ],
+  [24, { "side": "primary", "size": "secondary" }],
+  [25, { "variant": "primary" }],
+  [26, {}],
+  [27],
+  [28, {}],
+  [29, { "side": "ghost", "active": false }],
+  [
+    30,
+    {
+      "selected": true,
+      "className": "bg-secondary text-secondary-foreground hover:bg-secondary/80"
+    }
+  ],
+  [31, { "orientation": "secondary" }],
+  [32, {}],
+  [
+    33,
+    { "variant": "sm", "className": "rtl:**:[.rdp-button_next>svg]:rotate-180" }
+  ],
+  [34, { "size": "sm" }],
+  [35, { "side": "primary" }],
+  [36, { "color": "secondary", "orientation": "primary" }],
+  [37, {}],
+  [38, { "color": "outline" }],
+  [
+    39,
+    {
+      "tone": "outline",
+      "className": "cn-button group/button inline-flex shrink-0 items-center justify-center whitespace-nowrap transition-all outline-none select-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0"
+    }
+  ],
+  [40, { "side": "default", "orientation": "ghost" }],
+  [
+    41,
+    {
+      "className": "group-data-[size=default]/avatar:size-2.5 group-data-[size=default]/avatar:[&>svg]:size-2"
+    }
+  ],
+  [42, { "align": "secondary" }],
+  [43],
+  [44, {}],
+  [45, { "side": "ghost" }],
+  [46, { "color": "outline", "align": "outline" }],
+  [47, {}],
+  [0, { "size": "sm" }],
+  [1, {}],
+  [2],
+  [3, {}],
+  [4, { "loading": true }],
+  [5, { "align": "outline" }],
+  [6, { "tone": "primary" }],
+  [7, {}],
+  [8, {}],
+  [9, { "orientation": "outline" }],
+  [10],
+  [11, {}],
+  [12, { "selected": true, "className": "bottom-0 translate-y-3/4" }],
+  [13, {}],
+  [14, { "tone": "secondary" }],
+  [15, {}],
+  [16, { "className": "icon" }],
+  [17, { "tone": "outline", "orientation": "secondary" }],
+  [18, { "color": "primary" }],
+  [19],
+  [20, {}],
+  [21, {}],
+  [22, { "variant": "default", "size": "outline" }],
+  [23, { "orientation": "outline" }],
+  [24, { "side": "primary", "className": "cn-bubble-variant-ghost" }],
+  [25, { "variant": "primary" }],
+  [26, { "side": "default" }],
+  [27, { "size": "secondary" }],
+  [28, { "className": "aria-expanded:rotate-90" }],
+  [29, { "active": true }],
+  [30, { "selected": true }],
+  [31, { "orientation": "secondary" }],
+  [32, {}],
+  [33],
+  [34, {}],
+  [35, { "side": "primary" }],
+  [36, { "orientation": "secondary" }],
+  [
+    37,
+    {
+      "color": "primary",
+      "className": "-mt-3 hidden min-w-0 gap-2 md:flex md:flex-col md:**:[button,a]:w-full"
+    }
+  ],
+  [38, { "color": "default" }],
+  [39, { "tone": "secondary" }],
+  [40, { "side": "outline" }],
+  [41, { "orientation": "outline" }],
+  [
+    42,
+    {
+      "align": "primary",
+      "className": "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2"
+    }
+  ],
+  [43, { "className": "**:[.preview]:h-[560px]" }],
+  [44, { "size": "default" }],
+  [45, { "side": "md" }],
+  [46, {}],
+  [47, { "tone": "secondary" }],
+  [0, {}],
+  [1, { "variant": "secondary" }],
+  [2, { "color": "primary" }],
+  [3, { "variant": "sm", "className": "cn-bubble-reactions-align-end" }],
+  [4, { "loading": true }],
+  [5, { "align": "default" }],
+  [6, { "className": "block uppercase text-yellow-500 drop-shadow-md" }],
+  [7, {}],
+  [8, { "align": "outline" }],
+  [9, { "orientation": "secondary" }],
+  [10, {}],
+  [11, {}],
+  [12],
+  [13, {}],
+  [14, { "className": "absolute end-0 top-0" }],
+  [15, {}],
+  [16, { "align": "primary" }],
+  [17, {}],
+  [
+    18,
+    {
+      "color": "primary",
+      "className": "aspect-square w-full rounded-sm object-cover"
+    }
+  ],
+  [19, { "align": "ghost" }],
+  [20, { "orientation": "primary" }],
+  [21, { "align": "md" }],
+  [22, { "variant": "outline" }],
+  [23, { "orientation": "secondary" }],
+  [24, { "side": "primary", "size": "primary" }],
+  [25, { "variant": "primary" }],
+  [26, { "color": "primary" }],
+  [27],
+  [28, { "size": "secondary" }],
+  [
+    29,
+    {
+      "side": "outline",
+      "active": false,
+      "className": "bg-transparent font-mono"
+    }
+  ],
+  [30, {}],
+  [31, { "variant": "outline" }],
+  [32, {}],
+  [33, { "align": "default", "selected": false }],
+  [34, {}],
+  [35, { "side": "primary" }],
+  [36, { "color": "sm" }],
+  [37, {}],
+  [38, {}],
+  [
+    39,
+    {
+      "tone": "outline",
+      "className": "border style-vega:rounded-lg style-vega:p-6 style-nova:rounded-lg style-nova:p-4 style-lyra:rounded-none style-lyra:p-4 style-maia:rounded-xl style-maia:p-6 style-mira:rounded-md style-mira:p-4 style-luma:rounded-xl style-luma:p-6 style-sera:rounded-none style-sera:p-6 style-rhea:rounded-xl style-rhea:p-6"
+    }
+  ],
+  [40, { "side": "default", "loading": false }],
+  [41, { "orientation": "ghost" }],
+  [42, {}],
+  [
+    43,
+    {
+      "disabled": true,
+      "align": "ghost",
+      "className": "cn-command-dialog top-1/3 translate-y-0 overflow-hidden p-0"
+    }
+  ],
+  [44, { "loading": true }],
+  [45, { "side": "ghost" }],
+  [46, {}],
+  [47, { "tone": "ghost" }],
+  [0, { "size": "sm" }],
+  [
+    1,
+    { "className": "absolute inset-0 hidden w-[1600px] bg-background md:block" }
+  ],
+  [
+    2,
+    {
+      "color": "ghost",
+      "className": "absolute top-1 right-8 z-0 h-6! bg-foreground/5! peer-focus-visible:opacity-0 sm:right-7 sm:h-5!"
+    }
+  ],
+  [3],
+  [4, {}],
+  [
+    5,
+    { "align": "outline", "className": "absolute inset-0 bg-popover opacity-0" }
+  ],
+  [6, { "className": "cn-bubble-variant-destructive" }],
+  [7, { "size": "ghost", "className": "bg-muted" }],
+  [8, {}],
+  [9, {}],
+  [10, { "disabled": true, "align": "secondary" }],
+  [11, { "size": "default" }],
+  [12, {}],
+  [13, { "variant": "primary" }],
+  [14, {}],
+  [15, { "className": "aspect-square size-full" }],
+  [16, { "align": "primary", "color": "default" }],
+  [
+    17,
+    {
+      "tone": "secondary",
+      "className": "*:data-[slot=field-separator-content]:bg-card"
+    }
+  ],
+  [18, { "color": "primary" }],
+  [19, { "align": "default", "className": "cn-button-size-lg" }],
+  [20, {}],
+  [21, { "align": "md" }],
+  [
+    22,
+    {
+      "variant": "default",
+      "size": "secondary",
+      "className": "absolute top-1 right-8 z-0 h-6! bg-foreground/5! peer-focus-visible:opacity-0 sm:right-7 sm:h-5!"
+    }
+  ],
+  [23, { "orientation": "outline" }],
+  [
+    24,
+    {
+      "side": "primary",
+      "className": "cn-calendar-dropdown-root relative rounded-(--cell-radius)"
+    }
+  ],
+  [25, {}],
+  [26, { "side": "default" }],
+  [27, { "size": "secondary" }],
+  [28, { "size": "ghost" }],
+  [29, {}],
+  [30, {}],
+  [31, {}],
+  [32, { "size": "primary" }],
+  [33, {}],
+  [34, {}],
+  [
+    35,
+    { "side": "primary", "className": "aspect-3/4 h-fit w-fit object-cover" }
+  ],
+  [36, { "orientation": "primary" }],
+  [37, { "className": "cn-combobox-trigger-icon pointer-events-none" }],
+  [38, { "color": "ghost" }],
+  [39, { "tone": "secondary" }],
+  [
+    40,
+    { "loading": false, "className": "[--header-height:calc(--spacing(14))]" }
+  ],
+  [
+    41,
+    {
+      "orientation": "outline",
+      "className": "absolute inset-x-0 top-0 z-1 h-80 bg-linear-to-b from-background via-muted to-transparent dark:via-muted/30"
+    }
+  ],
+  [42, { "align": "primary" }],
+  [43, { "disabled": true, "className": "-ml-1 opacity-50 hover:opacity-100" }],
+  [44, { "loading": false }],
+  [45, { "side": "md" }],
+  [46, { "color": "primary" }],
+  [47, {}],
+  [0, { "size": "sm", "variant": "secondary" }],
+  [1, {}],
+  [2, {}],
+  [3, { "variant": "sm", "className": "bg-transparent" }],
+  [4, { "loading": true }],
+  [5, { "align": "ghost", "className": "-my-4 style-sera:hidden" }],
+  [6, { "loading": true }],
+  [7, {}],
+  [8, { "align": "secondary", "side": "primary" }],
+  [9, { "orientation": "outline" }],
+  [10, { "disabled": true, "align": "ghost", "orientation": "primary" }],
+  [11, { "size": "default" }],
+  [12, {}],
+  [13, { "variant": "secondary" }],
+  [14, { "tone": "secondary" }],
+  [
+    15,
+    { "className": "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2" }
+  ],
+  [16, { "align": "primary", "color": "ghost" }],
+  [
+    17,
+    { "className": "absolute top-4 right-4 z-10 rtl:right-auto rtl:left-4" }
+  ],
+  [18, { "color": "secondary" }],
+  [19, {}],
+  [20, {}],
+  [
+    21,
+    {
+      "side": "outline",
+      "className": "cn-card-action col-start-2 row-span-2 row-start-1 self-start justify-self-end"
+    }
+  ],
+  [22, { "variant": "default" }],
+  [23, { "orientation": "secondary" }],
+  [24, { "side": "primary", "selected": false }],
+  [25, {}],
+  [26, {}],
+  [27, { "size": "secondary" }],
+  [28, {}],
+  [29, {}],
+  [30, { "selected": false }],
+  [31],
+  [32, { "size": "primary" }],
+  [
+    33,
+    {
+      "align": "secondary",
+      "className": "group-data-[size=lg]/avatar:size-3 group-data-[size=lg]/avatar:[&>svg]:size-2"
+    }
+  ],
+  [34],
+  [35, {}],
+  [36, { "color": "sm", "orientation": "sm" }],
+  [
+    37,
+    {
+      "color": "sm",
+      "className": "cn-alert-dialog-overlay fixed inset-0 isolate z-50"
+    }
+  ],
+  [38, { "className": "cn-alert-dialog-overlay fixed inset-0 isolate z-50" }],
+  [39, { "tone": "ghost" }],
+  [40, { "side": "outline" }],
+  [41, { "orientation": "secondary", "className": "size-8" }],
+  [42, { "align": "primary" }],
+  [
+    43,
+    {
+      "disabled": true,
+      "align": "secondary",
+      "className": "absolute top-[0px] left-[122px] z-10 text-sm font-medium"
+    }
+  ],
+  [44, { "loading": true, "size": "default" }],
+  [45, { "side": "secondary", "className": "[--radius:9999rem]" }],
+  [
+    46,
+    {
+      "color": "primary",
+      "className": "border px-4 py-2 text-left font-bold [&[align=center]]:text-center [&[align=right]]:text-right"
+    }
+  ],
+  [
+    47,
+    {
+      "tone": "ghost",
+      "className": "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2"
+    }
+  ],
+  [0, {}],
+  [1],
+  [2, { "color": "primary" }],
+  [3, { "className": "animate-pulse text-red-500" }],
+  [4, {}],
+  [
+    5,
+    {
+      "align": "ghost",
+      "className": "absolute top-1/2 right-0 left-0 -translate-y-1/2 border-t-2 border-dotted border-muted-foreground/20"
+    }
+  ],
+  [6, {}],
+  [7],
+  [8, { "align": "primary", "side": "primary" }],
+  [9, {}],
+  [10, {}],
+  [
+    11,
+    {
+      "size": "secondary",
+      "className": "[&_svg]-h-3 h-6 w-6 rounded-[6px] bg-transparent text-foreground shadow-none hover:bg-muted dark:text-foreground [&_svg]:w-3"
+    }
+  ],
+  [12, {}],
+  [13, {}],
+  [14],
+  [15, {}],
+  [16, { "align": "primary" }],
+  [
+    17,
+    {
+      "tone": "outline",
+      "orientation": "outline",
+      "className": "cn-attachment-media relative flex aspect-square shrink-0 items-center justify-center overflow-hidden group-data-[state=error]/attachment:bg-destructive/10 group-data-[state=error]/attachment:text-destructive [&_svg]:pointer-events-none"
+    }
+  ],
+  [18, {}],
+  [19, { "align": "ghost" }],
+  [
+    20,
+    {
+      "orientation": "primary",
+      "className": "cn-attachment group/attachment relative flex max-w-full min-w-0 shrink-0 flex-wrap border bg-card text-card-foreground transition-colors has-[>a,>button]:hover:bg-muted/50 data-[state=error]:border-destructive/30 data-[state=idle]:border-dashed"
+    }
+  ],
+  [21, { "align": "outline" }],
+  [
+    22,
+    {
+      "variant": "default",
+      "className": "cn-button-group-orientation-horizontal **:data-slot:rounded-r-none [&_[data-slot]~[data-slot]]:rounded-l-none [&_[data-slot]~[data-slot]]:border-l-0"
+    }
+  ],
+  [23, { "orientation": "secondary" }],
+  [24, {}],
+  [25, { "variant": "primary" }],
+  [26, { "side": "outline", "color": "default" }],
+  [27, { "size": "outline" }],
+  [28, { "size": "primary" }],
+  [
+    29,
+    {
+      "side": "ghost",
+      "active": false,
+      "className": "-m-1.5 no-scrollbar flex gap-1 overflow-y-auto p-1.5"
+    }
+  ],
+  [30, { "selected": true }],
+  [31, { "orientation": "secondary", "variant": "primary" }],
+  [32],
+  [33, {}],
+  [
+    34,
+    {
+      "className": "absolute top-1/2 right-0 left-0 -translate-y-1/2 border-t-2 border-dotted border-muted-foreground/20"
+    }
+  ],
+  [35, { "side": "primary" }],
+  [
+    36,
+    {
+      "color": "sm",
+      "className": "cn-breadcrumb-ellipsis flex items-center justify-center"
+    }
+  ],
+  [37, { "color": "primary" }],
+  [38, { "color": "ghost" }],
+  [39, { "tone": "secondary" }],
+  [40, { "side": "sm" }],
+  [41, { "className": "h-9 px-4 py-2 has-[>svg]:px-3" }],
+  [42, { "align": "primary" }],
+  [43, { "disabled": false, "align": "ghost" }],
+  [44],
+  [45, {}],
+  [46, { "color": "secondary" }],
+  [47, { "tone": "ghost" }],
+  [0, { "size": "primary" }],
+  [1, {}],
+  [
+    2,
+    {
+      "color": "outline",
+      "className": "absolute top-2 right-2 border bg-background px-2 py-1 text-[0.625rem]"
+    }
+  ],
+  [3],
+  [
+    4,
+    {
+      "loading": true,
+      "className": "group-data-[size=default]/avatar:size-2.5 group-data-[size=default]/avatar:[&>svg]:size-2"
+    }
+  ],
+  [5, { "align": "ghost" }],
+  [6, { "tone": "secondary", "loading": false }],
+  [7, {}],
+  [8, { "align": "secondary" }],
+  [9, { "orientation": "secondary" }],
+  [10, { "disabled": true }],
+  [11, {}],
+  [12, {}],
+  [
+    13,
+    {
+      "className": "aspect-square size-4 rounded-full border border-dashed border-muted-foreground"
+    }
+  ],
+  [14, { "tone": "outline" }],
+  [15],
+  [
+    16,
+    {
+      "className": "bg-blue-600 text-blue-50 dark:bg-blue-600 dark:text-blue-50"
+    }
+  ],
+  [17, { "tone": "secondary", "className": "cn-bubble-variant-tinted" }],
+  [18, { "color": "secondary" }],
+  [19, { "align": "default" }],
+  [20, { "orientation": "primary" }],
+  [21, { "align": "secondary" }],
+  [22, {}],
+  [23, { "orientation": "outline", "loading": true }],
+  [24, { "side": "primary", "size": "primary" }],
+  [25],
+  [
+    26,
+    {
+      "className": "cn-combobox-content cn-combobox-content-logical cn-menu-target cn-menu-translucent group/combobox-content relative max-h-(--available-height) w-(--anchor-width) max-w-(--available-width) min-w-[calc(var(--anchor-width)+--spacing(7))] origin-(--transform-origin) data-[chips=true]:min-w-(--anchor-width)"
+    }
+  ],
+  [27, { "size": "secondary", "className": "bg-muted font-semibold" }],
+  [28, {}],
+  [29, { "active": true }],
+  [30, {}],
+  [31, { "orientation": "secondary", "variant": "outline" }],
+  [32, { "size": "ghost" }],
+  [
+    33,
+    {
+      "variant": "sm",
+      "align": "secondary",
+      "className": "cn-carousel-next absolute touch-manipulation"
+    }
+  ],
+  [34, { "size": "sm" }],
+  [35, { "side": "primary" }],
+  [36, { "color": "primary", "orientation": "secondary" }],
+  [37, { "color": "secondary" }],
+  [38, { "color": "default" }],
+  [39, { "className": "cn-bubble-reactions-align-start" }],
+  [40, { "loading": true }],
+  [41, { "orientation": "ghost" }],
+  [42, { "align": "secondary" }],
+  [43, {}],
+  [44, { "loading": false, "size": "outline" }],
+  [45, { "side": "md" }],
+  [46, { "color": "primary", "className": "cn-button-variant-destructive" }],
+  [47, { "tone": "secondary" }],
+  [0],
+  [1, { "variant": "sm" }],
+  [2, { "color": "outline" }],
+  [3, { "variant": "outline" }],
+  [4, { "loading": false }],
+  [5, { "align": "default" }],
+  [6, { "tone": "sm", "loading": true }],
+  [7, { "size": "secondary", "className": "aspect-auto h-[250px] w-full" }],
+  [8, { "align": "primary" }],
+  [9, { "orientation": "secondary" }],
+  [10, { "disabled": true, "align": "ghost" }],
+  [11, { "size": "secondary" }],
+  [12, { "selected": false }],
+  [13, { "className": "bg-green-600 dark:bg-green-800" }],
+  [14, { "tone": "outline" }],
+  [15, {}],
+  [16, { "className": "cn-combobox-chips" }],
+  [
+    17,
+    {
+      "tone": "primary",
+      "className": "bg-background hover:bg-background/80 data-popup-open:bg-background"
+    }
+  ],
+  [18, { "color": "primary" }],
+  [
+    19,
+    {
+      "align": "secondary",
+      "className": "cn-badge group/badge inline-flex w-fit shrink-0 items-center justify-center overflow-hidden whitespace-nowrap focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none"
+    }
+  ],
+  [20, {}],
+  [21, {}],
+  [22, { "variant": "default" }],
+  [23, { "orientation": "secondary" }],
+  [24, { "side": "primary", "size": "primary" }],
+  [25, { "variant": "primary" }],
+  [26, { "color": "default" }],
+  [27, { "size": "outline", "className": "[&_tr:last-child]:border-0" }],
+  [28, { "size": "primary" }],
+  [
+    29,
+    {
+      "side": "outline",
+      "className": "absolute inset-y-0 right-0 left-62 z-40 bg-transparent"
+    }
+  ],
+  [30, { "selected": false, "className": "border border-dashed" }],
+  [31, {}],
+  [32, { "size": "ghost" }],
+  [
+    33,
+    {
+      "variant": "outline",
+      "align": "secondary",
+      "className": "cn-alert-dialog-content group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 outline-none"
+    }
+  ],
+  [34, { "size": "ghost", "align": "primary" }],
+  [35, { "side": "primary" }],
+  [36, { "className": "cn-command-shortcut" }],
+  [
+    37,
+    { "className": "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2" }
+  ],
+  [38, {}],
+  [
+    39,
+    {
+      "tone": "outline",
+      "className": "cn-combobox-clear-icon pointer-events-none"
+    }
+  ],
+  [40, { "side": "default" }],
+  [41, { "orientation": "outline", "className": "cn-context-menu-shortcut" }],
+  [42, {}],
+  [43, { "disabled": false }],
+  [44, { "size": "outline" }],
+  [
+    45,
+    {
+      "className": "bg-purple-600 text-purple-50 dark:bg-purple-600 dark:text-purple-50"
+    }
+  ],
+  [46, {}],
+  [
+    47,
+    {
+      "className": "border-ghost w-full flex-1 rounded-md bg-(--bg) after:rounded-lg after:border-input md:rounded-lg"
+    }
+  ],
+  [0, { "size": "primary", "variant": "primary" }],
+  [1, { "variant": "ghost" }],
+  [2, { "color": "primary" }],
+  [3, {}],
+  [4, { "className": "border-t bg-card" }],
+  [5, { "align": "default" }],
+  [
+    6,
+    {
+      "loading": true,
+      "className": "border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted"
+    }
+  ],
+  [7, {}],
+  [8, {}],
+  [9, { "orientation": "outline" }],
+  [10, {}],
+  [
+    11,
+    {
+      "size": "primary",
+      "className": "cn-bubble-reactions absolute z-10 flex w-fit items-center justify-center"
+    }
+  ],
+  [
+    12,
+    {
+      "className": "cn-accordion-trigger-icon pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+    }
+  ],
+  [13, { "variant": "secondary" }],
+  [14, { "tone": "secondary" }],
+  [15, {}],
+  [16, { "className": "cn-command-separator" }],
+  [17, { "orientation": "secondary" }],
+  [18],
+  [19, {}],
+  [20, { "orientation": "primary" }],
+  [
+    21,
+    {
+      "align": "secondary",
+      "side": "outline",
+      "className": "cn-attachment-media relative flex aspect-square shrink-0 items-center justify-center overflow-hidden group-data-[state=error]/attachment:bg-destructive/10 group-data-[state=error]/attachment:text-destructive [&_svg]:pointer-events-none"
+    }
+  ],
+  [22, { "size": "secondary" }],
+  [23, { "loading": false, "className": "absolute inset-0 top-1/2" }],
+  [24, { "side": "primary" }],
+  [25, { "variant": "primary" }],
+  [26, { "side": "default" }],
+  [27, { "className": "cn-accordion flex w-full flex-col" }],
+  [28, {}],
+  [29, { "active": true }],
+  [
+    30,
+    {
+      "selected": true,
+      "className": "cn-bubble group/bubble relative flex w-fit min-w-0 flex-col"
+    }
+  ],
+  [31, { "variant": "primary" }],
+  [32, { "size": "primary" }],
+  [33, { "variant": "sm" }],
+  [34, { "size": "outline", "align": "primary" }],
+  [35, {}],
+  [36, {}],
+  [37, {}],
+  [38, { "color": "default", "className": "-mr-1 ml-auto rotate-180" }],
+  [39, { "tone": "ghost" }],
+  [40, { "side": "sm", "loading": false, "orientation": "ghost" }],
+  [41, { "orientation": "outline" }],
+  [42, { "align": "primary", "className": "cn-attachment-action" }],
+  [43, { "disabled": false }],
+  [44, { "loading": true }],
+  [45, { "side": "ghost" }],
+  [46, { "color": "outline" }],
+  [47, { "tone": "ghost" }],
+  [0, { "size": "sm" }],
+  [1, { "orientation": "secondary" }],
+  [2, {}],
+  [3, { "variant": "secondary" }],
+  [4, { "loading": false, "className": "cn-button-variant-outline" }],
+  [5, {}],
+  [6, {}],
+  [
+    7,
+    {
+      "className": "group-data-[size=lg]/avatar:size-3 group-data-[size=lg]/avatar:[&>svg]:size-2"
+    }
+  ],
+  [
+    8,
+    {
+      "align": "outline",
+      "className": "absolute inset-x-0 bottom-0 rounded-sm bg-chart-3"
+    }
+  ],
+  [9, { "orientation": "secondary" }],
+  [10, { "disabled": false }],
+  [11, { "size": "secondary" }],
+  [12, { "selected": false }],
+  [13, { "variant": "secondary" }],
+  [14, { "tone": "primary" }],
+  [15],
+  [16, { "align": "primary" }],
+  [17, { "tone": "outline" }],
+  [18, { "color": "primary" }],
+  [19, {}],
+  [20, { "orientation": "primary" }],
+  [
+    21,
+    { "side": "outline", "className": "[--header-height:calc(--spacing(14))]" }
+  ],
+  [
+    22,
+    {
+      "variant": "outline",
+      "className": "cn-attachment-actions flex shrink-0 items-center"
+    }
+  ],
+  [23, { "orientation": "outline" }],
+  [24, { "side": "primary" }],
+  [25, { "variant": "primary" }],
+  [26, {}],
+  [27, {}],
+  [28, {}],
+  [29, { "side": "outline", "active": false }],
+  [30, { "selected": true }],
+  [31, { "variant": "outline", "className": "[--radius:9999rem]" }],
+  [32, {}],
+  [33, { "variant": "outline" }],
+  [34, {}],
+  [35, { "side": "primary" }],
+  [
+    36,
+    {
+      "color": "primary",
+      "orientation": "outline",
+      "className": "cn-checkbox peer relative shrink-0 outline-none after:absolute after:-inset-x-3 after:-inset-y-2 disabled:cursor-not-allowed disabled:opacity-50"
+    }
+  ],
+  [37, { "color": "sm" }],
+  [38, {}],
+  [39, { "tone": "secondary" }],
+  [40, {}],
+  [41, {}],
+  [42, {}],
+  [43, { "disabled": true, "align": "ghost" }],
+  [44],
+  [45, { "side": "md" }],
+  [46],
+  [47, { "tone": "secondary" }],
+  [
+    0,
+    { "size": "ghost", "variant": "secondary", "className": "animate-none!" }
+  ],
+  [1, { "orientation": "secondary" }],
+  [2, {}],
+  [3],
+  [4, { "loading": true, "className": "cn-button-size-icon-sm" }],
+  [5, { "align": "ghost" }],
+  [6, { "tone": "primary", "loading": true }],
+  [7, { "size": "ghost" }],
+  [8, { "align": "primary", "side": "outline" }],
+  [9, {}],
+  [10, { "disabled": true }],
+  [
+    11,
+    {
+      "size": "default",
+      "className": "absolute top-12 right-2 bottom-0 hidden h-full w-px bg-[linear-gradient(to_bottom,transparent_0%,var(--border)_10%,var(--border)_90%,transparent_100%)] lg:flex"
+    }
+  ],
+  [12, { "selected": false, "className": "cn-context-menu-separator" }],
+  [13, { "variant": "ghost", "className": "-mx-6" }],
+  [
+    14,
+    {
+      "tone": "secondary",
+      "className": "cn-breadcrumb-item inline-flex items-center"
+    }
+  ],
+  [15, {}],
+  [16, { "align": "primary", "color": "ghost", "className": "size-10" }],
+  [17, { "tone": "default" }],
+  [18, { "color": "secondary", "active": false }],
+  [19, { "align": "default" }],
+  [20, { "orientation": "primary" }],
+  [21, { "align": "primary" }],
+  [22, { "variant": "outline" }],
+  [23, { "className": "h-9 min-w-9 px-2" }],
+  [24, { "side": "primary" }],
+  [25, { "variant": "primary" }],
+  [
+    26,
+    {
+      "side": "outline",
+      "className": "cn-alert-dialog-content group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 outline-none"
+    }
+  ],
+  [27, {}],
+  [28, {}],
+  [29, { "side": "ghost" }],
+  [30, { "selected": true }],
+  [31, { "variant": "primary" }],
+  [32, {}],
+  [33, { "variant": "outline", "className": "cn-combobox-chip-remove" }],
+  [34, { "size": "outline", "align": "outline" }],
+  [35, { "side": "primary" }],
+  [36, {}],
+  [37, { "className": "cn-command-list overflow-x-hidden overflow-y-auto" }],
+  [38, { "color": "default" }],
+  [39, {}],
+  [40, { "side": "outline", "loading": true }],
+  [41, { "orientation": "default" }],
+  [42],
+  [43, {}],
+  [44, {}],
+  [
+    45,
+    {
+      "className": "absolute z-10 flex w-fit shrink-0 items-center justify-center gap-1 rounded-full bg-muted px-1.5 py-0.5 text-sm ring-3 ring-card has-[button]:p-0"
+    }
+  ],
+  [46, { "color": "primary" }],
+  [47, {}],
+  [0, { "size": "primary" }],
+  [1, { "className": "bottom" }],
+  [2, { "color": "primary" }],
+  [3, {}],
+  [4, {}],
+  [5, { "align": "default" }],
+  [6, { "tone": "secondary" }],
+  [7, { "size": "ghost" }],
+  [8, {}],
+  [9, { "orientation": "outline" }],
+  [10, { "disabled": true }],
+  [11, {}],
+  [12, { "selected": false }],
+  [13, {}],
+  [14, {}],
+  [15, { "className": "cn-alert-dialog-description" }],
+  [
+    16,
+    {
+      "align": "primary",
+      "className": "block truncate text-xs text-muted-foreground"
+    }
+  ],
+  [17, { "tone": "secondary" }],
+  [18, { "color": "primary", "active": false }],
+  [19, { "align": "secondary" }],
+  [20, { "orientation": "primary" }],
+  [
+    21,
+    {
+      "align": "primary",
+      "className": "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize"
+    }
+  ],
+  [22],
+  [23, { "orientation": "outline" }],
+  [24, { "side": "primary", "size": "secondary", "selected": true }],
+  [25, {}],
+  [26, { "side": "outline" }],
+  [27, {}],
+  [28, { "size": "primary", "className": "cn-combobox-empty" }],
+  [
+    29,
+    { "side": "outline", "active": true, "className": "top-[0.4rem] rotate-45" }
+  ],
+  [30],
+  [31, { "orientation": "secondary", "variant": "primary" }],
+  [32, { "size": "primary" }],
+  [33, { "variant": "outline" }],
+  [34, { "size": "primary" }],
+  [35, { "side": "primary" }],
+  [36, {}],
+  [37],
+  [38, { "color": "outline" }],
+  [39, {}],
+  [40, { "side": "sm", "loading": false }],
+  [41, { "orientation": "default", "className": "cn-attachment-size-sm" }],
+  [42, { "align": "secondary" }],
+  [43, { "disabled": true, "align": "secondary" }],
+  [44, { "loading": true }],
+  [45, {}],
+  [46, { "color": "outline" }],
+  [
+    47,
+    {
+      "tone": "ghost",
+      "className": "absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform peer-hover/menu-button:text-sidebar-accent-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0"
+    }
+  ]
+]

--- a/packages/conformance/bench/cva/cva-sites.json
+++ b/packages/conformance/bench/cva/cva-sites.json
@@ -1,0 +1,860 @@
+[
+  {
+    "base": "-mx-4 w-[140vw] overflow-hidden md:hidden",
+    "config": {
+      "variants": {
+        "size": {
+          "primary": "[&::-webkit-search-cancel-button]:hidden",
+          "ghost": "bg-purple-600 text-purple-50 dark:bg-purple-600 dark:text-purple-50",
+          "sm": "cn-context-menu-trigger select-none"
+        },
+        "variant": {
+          "primary": "absolute top-1.5 right-9 z-10 flex items-center",
+          "secondary": "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+          "ghost": "absolute inset-x-0 -bottom-2 flex h-20 items-center justify-center rounded-b-lg bg-gradient-to-b from-code/70 to-code text-sm text-muted-foreground group-data-[state=open]/collapsible:hidden"
+        }
+      },
+      "defaultVariants": { "size": "sm", "variant": "ghost" },
+      "compoundVariants": [
+        {
+          "size": "ghost",
+          "variant": ["primary", "primary"],
+          "class": "[--header-height:calc(--spacing(14))]"
+        },
+        { "variant": "ghost", "class": "[--radius:1rem]" },
+        { "class": "icon" },
+        { "size": "ghost", "class": "-mx-1 no-scrollbar overflow-x-hidden" },
+        {
+          "variant": ["primary", "primary"],
+          "class": "absolute inset-0 top-1/2"
+        },
+        {
+          "size": "ghost",
+          "variant": ["ghost", "primary"],
+          "class": "bg-muted font-semibold"
+        },
+        { "size": "sm", "class": "block text-sm font-medium text-gray-700" },
+        {
+          "size": "primary",
+          "variant": "ghost",
+          "className": "absolute inset-0 opacity-0"
+        },
+        {
+          "class": "cn-attachment group/attachment relative flex max-w-full min-w-0 shrink-0 flex-wrap border bg-card text-card-foreground transition-colors has-[>a,>button]:hover:bg-muted/50 data-[state=error]:border-destructive/30 data-[state=idle]:border-dashed"
+        },
+        { "class": "-mx-1" },
+        { "size": "primary", "className": "cn-badge-variant-default" }
+      ]
+    }
+  },
+  {
+    "base": ["cn-button-size-icon", "cn-alert-variant-default"],
+    "config": {
+      "variants": {
+        "variant": {
+          "secondary": "absolute inset-x-0 top-0 z-1 h-80 bg-linear-to-b from-background via-muted to-transparent dark:via-muted/30",
+          "outline": "animate-none! sm:max-w-md",
+          "ghost": "bg-transparent [--cell-size:2.1rem]",
+          "sm": ["h-9 px-4 py-2 has-[>svg]:px-3", "bottom"]
+        },
+        "orientation": {
+          "secondary": "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
+          "primary": "cn-accordion-content overflow-hidden",
+          "outline": "absolute inset-0 hidden w-[1600px] bg-background md:block"
+        }
+      },
+      "defaultVariants": { "variant": "sm", "orientation": "secondary" }
+    }
+  },
+  {
+    "base": "h-9 px-4 py-2 has-[>svg]:px-3",
+    "config": {
+      "variants": {
+        "color": {
+          "primary": "bg-transparent font-mono",
+          "outline": "h-10 min-w-10 px-2.5",
+          "ghost": ["cn-button-variant-outline", "[&_.preview]:items-start"]
+        }
+      }
+    }
+  },
+  {
+    "base": "cn-command-input-icon",
+    "config": {
+      "variants": {
+        "variant": {
+          "secondary": "basis-1/2 pt-1",
+          "outline": "block border-b p-4 text-xl",
+          "sm": "h-9 px-4 py-2 has-[>svg]:px-3"
+        }
+      },
+      "defaultVariants": { "variant": "outline" }
+    }
+  },
+  {
+    "base": "-ml-3 h-8 data-[state=open]:bg-accent",
+    "config": {
+      "variants": {
+        "loading": {
+          "true": "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+          "false": "border-b"
+        }
+      }
+    }
+  },
+  {
+    "base": "[&_.preview]:h-[350px] [&_pre]:h-[350px]!",
+    "config": {
+      "variants": {
+        "align": {
+          "default": "absolute inset-y-0 right-0 left-62 z-40 bg-transparent",
+          "outline": "peer-data-[size=sm]/menu-button:top-1",
+          "ghost": "cn-attachment-size-xs",
+          "sm": "cn-command-shortcut cn-command-shortcut-aria"
+        },
+        "color": {
+          "default": "-mb-(--card-spacing)",
+          "primary": "cn-button-group-orientation-vertical flex-col **:data-slot:rounded-b-none [&_[data-slot]~[data-slot]]:rounded-t-none [&_[data-slot]~[data-slot]]:border-t-0",
+          "ghost": "cn-dialog-footer flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+          "sm": "-mx-6"
+        }
+      },
+      "defaultVariants": { "align": "sm", "color": "primary" }
+    }
+  },
+  {
+    "base": "bg-[Canvas] text-[CanvasText]",
+    "config": {
+      "variants": {
+        "tone": {
+          "secondary": [
+            "after:absolute after:-inset-2 md:after:hidden",
+            "aspect-square w-full rounded-sm object-cover"
+          ],
+          "primary": "absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 fill-primary",
+          "sm": "cn-context-menu-separator"
+        },
+        "loading": {
+          "true": "absolute inset-y-0 right-0 left-54 z-40 bg-transparent",
+          "false": "capitalize data-[state=checked]:opacity-50"
+        }
+      },
+      "defaultVariants": { "tone": "sm" }
+    }
+  },
+  {
+    "base": "cn-button-size-icon-sm",
+    "config": {
+      "variants": {
+        "size": {
+          "secondary": "absolute top-2 right-2 border bg-background px-2 py-1 text-[0.625rem]",
+          "ghost": "cn-button-variant-outline"
+        }
+      },
+      "defaultVariants": { "size": "secondary" }
+    }
+  },
+  {
+    "base": "chart-wrapper hidden theme-container sm:block [&_[data-chart]]:mx-auto [&_[data-chart]]:max-h-[35vh] [&>div]:rounded-none [&>div]:border-0 [&>div]:border-b [&>div]:shadow-none",
+    "config": {
+      "variants": {
+        "align": {
+          "primary": "absolute inset-0 bg-[color:rgba(254,204,27,0.5)] mix-blend-multiply",
+          "outline": "inset-y-0 -left-12 my-auto",
+          "secondary": [
+            "cn-breadcrumb-link",
+            "cn-attachment-media-variant-image *:[img]:aspect-square *:[img]:w-full *:[img]:object-cover"
+          ]
+        },
+        "side": {
+          "primary": [
+            "cn-context-menu-label",
+            "cn-avatar-badge absolute right-0 bottom-0 z-10 inline-flex items-center justify-center rounded-full bg-blend-color ring-2 select-none"
+          ],
+          "outline": "animate-pulse rounded-md bg-accent"
+        }
+      },
+      "defaultVariants": { "align": "outline", "side": "primary" }
+    }
+  },
+  {
+    "base": [
+      "cn-command flex size-full flex-col overflow-hidden",
+      "cn-alert-variant-default"
+    ],
+    "config": {
+      "variants": {
+        "orientation": {
+          "secondary": "absolute inset-x-0 top-0 z-1 h-80 bg-linear-to-b from-background via-muted to-transparent dark:via-muted/30",
+          "outline": "-ms-6 translate-x-1 rounded-full transition-all duration-100 ease-linear data-checked:ms-0 data-checked:translate-x-0"
+        }
+      },
+      "defaultVariants": { "orientation": "outline" }
+    }
+  },
+  {
+    "base": "cn-context-menu-sub-content-aria cn-menu-target cn-menu-translucent w-auto",
+    "config": {
+      "variants": {
+        "disabled": {
+          "true": "*:data-[slot=input-otp-slot]:text-xl style-vega:*:data-[slot=input-otp-slot]:h-16 style-vega:*:data-[slot=input-otp-slot]:w-12 style-nova:*:data-[slot=input-otp-slot]:h-12 style-nova:*:data-[slot=input-otp-slot]:w-11 style-lyra:*:data-[slot=input-otp-slot]:h-12 style-lyra:*:data-[slot=input-otp-slot]:w-11 style-maia:*:data-[slot=input-otp-slot]:h-16 style-maia:*:data-[slot=input-otp-slot]:w-12 style-mira:*:data-[slot=input-otp-slot]:h-12 style-mira:*:data-[slot=input-otp-slot]:w-11 style-luma:*:data-[slot=input-otp-slot]:h-16 style-luma:*:data-[slot=input-otp-slot]:w-12 style-sera:*:data-[slot=input-otp-slot]:h-14 style-sera:*:data-[slot=input-otp-slot]:w-10",
+          "false": "-mr-1 ml-auto rotate-180"
+        },
+        "align": {
+          "primary": "cn-combobox-item cn-combobox-item-aria relative flex w-full cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+          "secondary": [
+            "cn-command-shortcut cn-command-shortcut-aria",
+            "cn-calendar group/calendar w-fit bg-background in-data-[slot=card-content]:bg-transparent in-data-[slot=popover-content]:bg-transparent"
+          ],
+          "ghost": "cn-accordion-trigger group/accordion-trigger relative flex flex-1 items-start justify-between border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50"
+        },
+        "orientation": {
+          "secondary": "cn-combobox-trigger",
+          "primary": "absolute size-8 rounded-full",
+          "outline": "absolute inset-x-0 bottom-0 z-20 h-80 bg-linear-to-t from-background via-muted to-transparent dark:via-muted/30",
+          "sm": "cn-checkbox cn-checkbox-aria peer relative shrink-0 outline-none after:absolute after:-inset-x-3 after:-inset-y-2 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50",
+          "md": "aria-expanded:bg-sidebar-accent aria-expanded:text-sidebar-accent-foreground"
+        }
+      },
+      "defaultVariants": {
+        "disabled": false,
+        "align": "ghost",
+        "orientation": "md"
+      }
+    }
+  },
+  {
+    "base": "[&::-webkit-search-cancel-button]:hidden",
+    "config": {
+      "variants": {
+        "size": {
+          "default": "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+          "primary": "cn-checkbox-indicator grid place-content-center text-current transition-none",
+          "secondary": "bottom"
+        }
+      },
+      "defaultVariants": { "size": "default" }
+    }
+  },
+  {
+    "base": [
+      "absolute top-2 right-2 border bg-background px-2 py-1 text-[0.625rem]",
+      "cn-combobox-chip-input min-w-16 flex-1 outline-none"
+    ],
+    "config": {
+      "variants": {
+        "selected": {
+          "true": "[&_.preview]:h-[400px] [&_pre]:h-[400px]!",
+          "false": "bg-blue-500 text-white dark:bg-blue-600"
+        }
+      }
+    }
+  },
+  {
+    "base": [
+      "bg-destructive/10 text-destructive dark:bg-destructive/20 dark:text-destructive",
+      "rtl:**:[.rdp-button_next>svg]:rotate-180"
+    ],
+    "config": {
+      "variants": {
+        "variant": {
+          "primary": "cn-context-menu-separator",
+          "secondary": "aspect-video h-12 w-full rounded-lg bg-muted/50",
+          "ghost": "absolute end-0 top-0"
+        }
+      },
+      "defaultVariants": { "variant": "primary" }
+    }
+  },
+  {
+    "base": "**:data-[slot=toggle-group-item]:data-pressed:bg-neutral-700/70",
+    "config": {
+      "variants": {
+        "tone": {
+          "primary": "icon",
+          "secondary": "cn-alert-action",
+          "outline": "*:data-[slot=field-separator-content]:bg-card"
+        }
+      },
+      "defaultVariants": { "tone": "outline" }
+    }
+  },
+  {
+    "base": "border style-vega:rounded-lg style-vega:p-6 style-nova:rounded-lg style-nova:p-4 style-lyra:rounded-none style-lyra:p-4 style-maia:rounded-xl style-maia:p-6 style-mira:rounded-md style-mira:p-4 style-luma:rounded-xl style-luma:p-6 style-sera:rounded-none style-sera:p-6 style-rhea:rounded-xl style-rhea:p-6",
+    "config": null
+  },
+  {
+    "base": "cn-avatar group/avatar relative flex shrink-0 select-none after:absolute after:inset-0 after:border after:border-border after:mix-blend-darken dark:after:mix-blend-lighten",
+    "config": {
+      "variants": {
+        "align": { "primary": "cn-dialog-title cn-font-heading" },
+        "color": {
+          "default": [
+            "[&_.preview]:h-[400px] [&_pre]:h-[400px]!",
+            "cn-combobox-list group/combobox-content max-h-[inherit] overflow-y-auto overscroll-contain"
+          ],
+          "secondary": [
+            "[&_[role=gridcell]]:w-[33px] [&_[role=gridcell].bg-accent]:bg-sidebar-primary [&_[role=gridcell].bg-accent]:text-sidebar-primary-foreground",
+            "animate-spin"
+          ],
+          "ghost": "bg-destructive/10 text-destructive dark:bg-destructive/20 dark:text-destructive"
+        }
+      },
+      "defaultVariants": { "align": "primary", "color": "secondary" }
+    }
+  },
+  {
+    "base": "bg-transparent [--cell-size:2.1rem]",
+    "config": {
+      "variants": {
+        "tone": {
+          "default": "cn-command-item cn-command-item-aria group/command-item data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+          "primary": "-mx-4 no-scrollbar max-h-[50vh] overflow-y-auto px-4",
+          "secondary": "bg-green-50 text-green-700 dark:bg-green-950 dark:text-green-300",
+          "outline": [
+            "cn-combobox-trigger group-has-data-[slot=combobox-clear]/input-group:hidden data-pressed:bg-transparent",
+            "cn-attachment-media relative flex aspect-square shrink-0 items-center justify-center overflow-hidden group-data-[state=error]/attachment:bg-destructive/10 group-data-[state=error]/attachment:text-destructive [&_svg]:pointer-events-none"
+          ]
+        },
+        "orientation": {
+          "secondary": "group-data-[size=sm]/avatar:size-2 group-data-[size=sm]/avatar:[&>svg]:hidden",
+          "outline": "@md/field-group:flex-col @2xl/field-group:flex-row"
+        }
+      },
+      "defaultVariants": { "tone": "secondary" }
+    }
+  },
+  {
+    "base": "[--header-height:calc(--spacing(14))]",
+    "config": {
+      "variants": {
+        "color": {
+          "primary": "bg-transparent",
+          "secondary": "absolute top-0 left-[calc(50%-950px-var(--rail-width)-var(--gap))] grid w-(--rail-width) grid-cols-[repeat(2,var(--rail-column))] gap-(--gap) opacity-50 [--rail-column:20rem] [--rail-width:calc(var(--rail-column)*2+var(--gap))]"
+        },
+        "active": {
+          "true": "cn-calendar group/calendar bg-background in-data-[slot=card-content]:bg-transparent in-data-[slot=popover-content]:bg-transparent",
+          "false": "cn-bubble-variant-ghost"
+        }
+      },
+      "defaultVariants": { "active": false }
+    }
+  },
+  {
+    "base": "absolute inset-0 z-10 outline-none",
+    "config": {
+      "variants": {
+        "align": {
+          "default": "-mt-1 h-[200px]",
+          "secondary": ["animate-spin", "absolute top-[50px] left-[5px] z-10"],
+          "ghost": "cn-alert-action"
+        }
+      },
+      "defaultVariants": { "align": "default" }
+    }
+  },
+  {
+    "base": "*:data-[slot=input-otp-slot]:text-xl style-vega:*:data-[slot=input-otp-slot]:h-16 style-vega:*:data-[slot=input-otp-slot]:w-12 style-nova:*:data-[slot=input-otp-slot]:h-12 style-nova:*:data-[slot=input-otp-slot]:w-11 style-lyra:*:data-[slot=input-otp-slot]:h-12 style-lyra:*:data-[slot=input-otp-slot]:w-11 style-maia:*:data-[slot=input-otp-slot]:h-16 style-maia:*:data-[slot=input-otp-slot]:w-12 style-mira:*:data-[slot=input-otp-slot]:h-12 style-mira:*:data-[slot=input-otp-slot]:w-11 style-luma:*:data-[slot=input-otp-slot]:h-16 style-luma:*:data-[slot=input-otp-slot]:w-12",
+    "config": {
+      "variants": {
+        "orientation": {
+          "primary": "absolute -top-12 right-52 hidden h-8! data-[size=sm]:rounded-lg lg:flex"
+        }
+      }
+    }
+  },
+  {
+    "base": "cn-command-item group/command-item data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+    "config": {
+      "variants": {
+        "align": {
+          "primary": "-mt-3 hidden min-w-0 gap-2 md:flex md:flex-col md:**:[button,a]:w-full",
+          "secondary": "-translate-x-[2px]",
+          "ghost": "cn-drawer-content group/drawer-content fixed z-50 data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=left]:sm:max-w-sm data-[vaul-drawer-direction=right]:sm:max-w-sm",
+          "outline": "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+          "md": "flex-col [&>*:not(:first-child)]:rounded-t-none [&>*:not(:first-child)]:border-t-0 [&>*:not(:last-child)]:rounded-b-none"
+        },
+        "side": {
+          "default": "bg-background hover:bg-background/80 data-popup-open:bg-background",
+          "primary": "h-9 min-w-9 px-2",
+          "outline": [
+            "*:data-[slot=input-otp-slot]:text-xl style-vega:*:data-[slot=input-otp-slot]:h-16 style-vega:*:data-[slot=input-otp-slot]:w-12 style-nova:*:data-[slot=input-otp-slot]:h-12 style-nova:*:data-[slot=input-otp-slot]:w-11 style-lyra:*:data-[slot=input-otp-slot]:h-12 style-lyra:*:data-[slot=input-otp-slot]:w-11 style-maia:*:data-[slot=input-otp-slot]:h-16 style-maia:*:data-[slot=input-otp-slot]:w-12 style-mira:*:data-[slot=input-otp-slot]:h-12 style-mira:*:data-[slot=input-otp-slot]:w-11 style-luma:*:data-[slot=input-otp-slot]:h-16 style-luma:*:data-[slot=input-otp-slot]:w-12 style-sera:*:data-[slot=input-otp-slot]:h-14 style-sera:*:data-[slot=input-otp-slot]:w-10",
+            "aria-expanded:rotate-90"
+          ]
+        },
+        "variant": {
+          "primary": "absolute inset-0 h-full w-full object-cover dark:brightness-[0.2] dark:grayscale",
+          "outline": "cn-alert-dialog-header",
+          "secondary": "cn-context-menu-content cn-context-menu-content-logical cn-menu-target cn-menu-translucent z-50 max-h-(--available-height) origin-(--transform-origin) overflow-x-hidden overflow-y-auto outline-none",
+          "ghost": "absolute top-0 left-0 z-20 h-full w-[1600px] max-w-none bg-background object-cover object-left-top md:hidden dark:hidden md:dark:hidden",
+          "md": "cn-context-menu-label"
+        }
+      },
+      "defaultVariants": { "side": "outline", "variant": "md" }
+    }
+  },
+  {
+    "base": [
+      "border-grid",
+      "absolute inset-0 h-full w-full object-cover dark:brightness-[0.2] dark:grayscale"
+    ],
+    "config": {
+      "variants": {
+        "variant": {
+          "default": [
+            "cn-calendar-dropdown-root relative rounded-(--cell-radius)",
+            "cn-dialog-content-aria fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none"
+          ],
+          "outline": "aspect-auto h-[250px] w-full"
+        },
+        "size": {
+          "secondary": "absolute inset-0 right-4 [background-image:radial-gradient(#d4d4d4_1px,transparent_1px)] [background-size:20px_20px] dark:[background-image:radial-gradient(#404040_1px,transparent_1px)]",
+          "outline": "cn-button group/button inline-flex shrink-0 items-center justify-center whitespace-nowrap transition-all outline-none select-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0"
+        }
+      }
+    }
+  },
+  {
+    "base": "before:mr-1 before:h-px before:min-w-0 before:flex-1 before:bg-border after:ml-1 after:h-px after:min-w-0 after:flex-1 after:bg-border",
+    "config": {
+      "variants": {
+        "orientation": {
+          "secondary": "border style-vega:rounded-lg style-vega:p-6 style-nova:rounded-lg style-nova:p-4 style-lyra:rounded-none style-lyra:p-4 style-maia:rounded-xl style-maia:p-6 style-mira:rounded-md style-mira:p-4 style-luma:rounded-xl style-luma:p-6 style-sera:rounded-none style-sera:p-6 style-rhea:rounded-xl style-rhea:p-6",
+          "outline": "cn-context-menu-item group/context-menu-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0"
+        },
+        "loading": {
+          "true": "absolute top-2 right-2 z-10 size-7 opacity-70 hover:opacity-100 focus-visible:opacity-100",
+          "false": "**:data-[slot=toggle-group-item]:data-pressed:bg-neutral-700/70"
+        }
+      },
+      "defaultVariants": { "orientation": "outline" }
+    }
+  },
+  {
+    "base": "cn-avatar-fallback flex size-full items-center justify-center text-sm group-data-[size=sm]/avatar:text-xs peer-data-[state=error]:flex peer-[*]:hidden",
+    "config": {
+      "variants": {
+        "side": { "primary": "cn-alert-variant-destructive" },
+        "size": {
+          "primary": "absolute top-1/2 right-8 -translate-y-1/2",
+          "secondary": [
+            "cn-button-size-icon-lg",
+            "cn-bubble-content w-fit max-w-full min-w-0 overflow-hidden wrap-break-word [button]:text-left [button,a]:transition-colors"
+          ]
+        },
+        "selected": {
+          "true": "border",
+          "false": "cn-accordion-content overflow-hidden"
+        }
+      },
+      "defaultVariants": {
+        "side": "primary",
+        "size": "primary",
+        "selected": true
+      }
+    }
+  },
+  {
+    "base": "bg-black text-white",
+    "config": {
+      "variants": {
+        "variant": {
+          "primary": [
+            "border px-4 py-2 text-left font-bold [&[align=center]]:text-center [&[align=right]]:text-right",
+            "-mr-1 ml-auto rotate-180"
+          ]
+        }
+      },
+      "defaultVariants": { "variant": "primary" }
+    }
+  },
+  {
+    "base": "absolute inset-x-0 top-0 z-1 h-80 bg-linear-to-b from-background via-muted to-transparent dark:via-muted/30",
+    "config": {
+      "variants": {
+        "side": {
+          "default": [
+            "cn-dialog-content fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none",
+            "cn-button-size-sm"
+          ],
+          "outline": "cn-attachment-actions flex shrink-0 items-center"
+        },
+        "color": {
+          "default": "cn-alert-dialog-action",
+          "primary": "cn-context-menu-content cn-menu-target cn-menu-translucent z-50 max-h-(--radix-context-menu-content-available-height) origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto"
+        },
+        "variant": {
+          "default": "absolute inset-0 flex w-(--sidebar-menu-width) bg-transparent",
+          "primary": "bg-sky-600 text-sky-50 dark:bg-sky-600 dark:text-sky-50",
+          "outline": "bg-muted group-data-[swipe-axis=x]/drawer-popup:size-full group-data-[swipe-axis=y]/drawer-popup:aspect-video group-data-[swipe-axis=y]/drawer-popup:w-full",
+          "sm": "[&_svg]-h-3.5 h-7 w-7 rounded-[6px] [&_svg]:w-3.5"
+        }
+      },
+      "defaultVariants": {
+        "side": "outline",
+        "color": "primary",
+        "variant": "outline"
+      }
+    }
+  },
+  {
+    "base": "aspect-auto h-[250px] w-full",
+    "config": {
+      "variants": {
+        "size": {
+          "primary": "cn-alert-dialog-cancel",
+          "secondary": "border-0 py-4 shadow-none",
+          "outline": "cn-combobox-trigger-icon pointer-events-none"
+        }
+      }
+    }
+  },
+  {
+    "base": "cn-command-item cn-command-item-aria group/command-item data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+    "config": {
+      "variants": {
+        "size": {
+          "primary": "bg-green-600 dark:bg-green-800",
+          "secondary": "h-9 min-w-9 px-2",
+          "ghost": "aspect-square w-full rounded-sm object-cover",
+          "md": ["border-grid", "cn-card group/card flex flex-col"]
+        }
+      },
+      "defaultVariants": { "size": "ghost" }
+    }
+  },
+  {
+    "base": "absolute top-2 left-2 flex size-5 items-center justify-center bg-foreground text-background",
+    "config": {
+      "variants": {
+        "side": {
+          "secondary": "@container/main flex flex-1 flex-col gap-2",
+          "outline": "**:data-[slot=progress-indicator]:bg-chart-3",
+          "ghost": [
+            "cn-attachment-orientation-vertical flex-col",
+            "absolute top-0 right-[calc(50%-950px-var(--rail-width)-var(--gap))] grid w-(--rail-width) grid-cols-[repeat(2,var(--rail-column))] gap-(--gap) opacity-50 [--rail-column:20rem] [--rail-width:calc(var(--rail-column)*2+var(--gap))]"
+          ]
+        },
+        "active": {
+          "true": "cn-attachment-content max-w-full min-w-0 flex-1",
+          "false": "bg-transparent p-0"
+        }
+      },
+      "defaultVariants": { "side": "ghost", "active": false }
+    }
+  },
+  {
+    "base": "border px-4 py-2 text-start",
+    "config": {
+      "variants": {
+        "selected": {
+          "true": "cn-calendar-dropdown-root relative rounded-(--cell-radius)",
+          "false": "cn-command-item group/command-item data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0"
+        }
+      },
+      "defaultVariants": { "selected": true }
+    }
+  },
+  {
+    "base": "absolute h-[1.2rem] w-[1.2rem] scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0",
+    "config": {
+      "variants": {
+        "orientation": {
+          "secondary": "rtl:**:[.rdp-button_next>svg]:rotate-180"
+        },
+        "variant": {
+          "primary": "absolute top-2 left-2 flex size-5 items-center justify-center bg-foreground text-background",
+          "outline": "aria-expanded:text-destructive"
+        }
+      },
+      "defaultVariants": { "variant": "primary" }
+    }
+  },
+  {
+    "base": "border-b px-4 py-3",
+    "config": {
+      "variants": {
+        "size": {
+          "primary": "bg-blue-600 text-blue-50 dark:bg-blue-600 dark:text-blue-50",
+          "ghost": "bg-sky-50 text-sky-700 dark:bg-sky-950 dark:text-sky-300"
+        }
+      }
+    }
+  },
+  {
+    "base": [
+      "cn-combobox-item-indicator",
+      "cn-context-menu-content cn-menu-target cn-menu-translucent z-50 max-h-(--radix-context-menu-content-available-height) origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto"
+    ],
+    "config": {
+      "variants": {
+        "variant": {
+          "primary": "@md/field-group:flex-col @2xl/field-group:flex-row",
+          "outline": "cn-calendar-caption text-sm font-medium select-none",
+          "sm": [
+            "cn-button-size-icon-xs",
+            "absolute top-[10px] left-[85px] z-10 -scale-x-100"
+          ]
+        },
+        "align": {
+          "default": "cn-button-group-orientation-vertical flex-col *:data-slot:rounded-b-none [&>[data-slot]~[data-slot]]:rounded-t-none [&>[data-slot]~[data-slot]]:border-t-0",
+          "secondary": "cn-avatar-group-count relative flex shrink-0 items-center justify-center ring-2 ring-background"
+        },
+        "selected": {
+          "true": "cn-checkbox peer relative shrink-0 outline-none after:absolute after:-inset-x-3 after:-inset-y-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "false": "animate-none! rounded-lg shadow-none"
+        }
+      },
+      "defaultVariants": {
+        "variant": "primary",
+        "align": "secondary",
+        "selected": false
+      }
+    }
+  },
+  {
+    "base": "card",
+    "config": {
+      "variants": {
+        "size": {
+          "primary": "-mx-(--card-spacing) max-h-48 space-y-4 overflow-y-scroll border-t bg-muted/50 px-(--card-spacing) py-4 text-sm leading-relaxed",
+          "outline": [
+            "absolute inset-y-0 right-0 left-62 z-40 bg-transparent",
+            "cn-drawer-content group/drawer-content fixed z-50 data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=left]:sm:max-w-sm data-[vaul-drawer-direction=right]:sm:max-w-sm"
+          ],
+          "ghost": "bg-transparent p-0",
+          "sm": "absolute top-[50px] left-[5px] z-10",
+          "md": "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full hover:group-data-[collapsible=offcanvas]:bg-sidebar"
+        },
+        "align": {
+          "primary": "aspect-[4/3] w-full",
+          "outline": "@md/field-group:max-w-[200px]"
+        }
+      },
+      "defaultVariants": { "align": "outline" }
+    }
+  },
+  {
+    "base": "bg-destructive/10 text-destructive dark:bg-destructive/20 dark:text-destructive",
+    "config": { "variants": { "side": { "primary": "bg-transparent p-0" } } }
+  },
+  {
+    "base": "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
+    "config": {
+      "variants": {
+        "color": {
+          "secondary": "capitalize data-[state=checked]:opacity-50",
+          "primary": "cn-command-input-icon",
+          "sm": "cn-accordion-trigger-icon pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+        },
+        "orientation": {
+          "primary": "absolute top-1/2 right-8 -translate-y-1/2",
+          "outline": "cn-attachment-content max-w-full min-w-0 flex-1",
+          "secondary": "h-9 min-w-9 px-2",
+          "sm": "absolute right-1 bottom-1 bg-foreground/90 px-1 text-[0.5rem] font-semibold tracking-wider text-background"
+        }
+      },
+      "defaultVariants": { "color": "secondary" }
+    }
+  },
+  {
+    "base": "left-3",
+    "config": {
+      "variants": {
+        "color": {
+          "secondary": "cn-breadcrumb-ellipsis flex items-center justify-center",
+          "primary": "absolute inset-0 flex w-(--sidebar-width) bg-transparent",
+          "outline": ["absolute inset-0 top-1/2", "cn-attachment-action"],
+          "sm": "bg-sky-50 text-sky-700 dark:bg-sky-950 dark:text-sky-300"
+        }
+      },
+      "defaultVariants": { "color": "primary" }
+    }
+  },
+  {
+    "base": "border-ghost w-full flex-1 rounded-md bg-(--bg) after:rounded-lg after:border-input md:rounded-lg",
+    "config": {
+      "variants": {
+        "color": {
+          "default": "-ml-3 h-8 data-[state=open]:bg-accent",
+          "outline": "cn-card-footer flex items-center",
+          "ghost": [
+            "cn-alert-dialog-footer flex flex-col-reverse gap-2 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
+            "cn-badge-variant-default"
+          ]
+        }
+      }
+    }
+  },
+  {
+    "base": "cn-context-menu-radio-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+    "config": {
+      "variants": {
+        "tone": {
+          "secondary": "cn-alert-description [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground",
+          "outline": "**:data-[slot=progress-indicator]:bg-chart-3",
+          "ghost": "absolute inset-x-0 bottom-0 rounded-sm bg-chart-3"
+        }
+      }
+    }
+  },
+  {
+    "base": "cn-accordion-item",
+    "config": {
+      "variants": {
+        "side": {
+          "default": "-mx-2 my-2 w-auto!",
+          "outline": "cn-command-group",
+          "sm": "cn-attachment-title block max-w-full min-w-0 truncate group-data-[state=processing]/attachment:shimmer group-data-[state=uploading]/attachment:shimmer"
+        },
+        "loading": {
+          "true": "cn-chart-tooltip grid min-w-32 items-start",
+          "false": "absolute inset-0 top-1/2"
+        },
+        "orientation": {
+          "default": "cn-accordion-trigger group/accordion-trigger relative flex flex-1 items-start justify-between border border-transparent transition-all outline-none aria-disabled:pointer-events-none aria-disabled:opacity-50",
+          "secondary": "cn-combobox-chips",
+          "outline": "absolute inset-0 bg-[color:rgba(254,204,27,0.5)] mix-blend-multiply",
+          "ghost": "-mx-6"
+        }
+      },
+      "defaultVariants": { "orientation": "ghost" },
+      "compoundVariants": [
+        { "loading": false, "className": "right-3" },
+        {
+          "side": "sm",
+          "orientation": "ghost",
+          "class": "cn-breadcrumb-separator"
+        },
+        {
+          "side": "outline",
+          "orientation": "secondary",
+          "class": "aria-expanded:bg-sidebar-accent aria-expanded:text-sidebar-accent-foreground"
+        },
+        {
+          "side": "sm",
+          "orientation": "secondary",
+          "className": "peer-data-[size=sm]/menu-button:top-1"
+        },
+        {
+          "loading": false,
+          "orientation": ["ghost", "default"],
+          "className": "-mx-1 h-px bg-border"
+        },
+        {
+          "class": "[--cell-size:--spacing(10)] md:[--cell-size:--spacing(12)]"
+        }
+      ]
+    }
+  },
+  {
+    "base": "aria-expanded:rotate-90",
+    "config": {
+      "variants": {
+        "orientation": {
+          "default": "cn-carousel-previous absolute touch-manipulation",
+          "secondary": "horizontal",
+          "outline": [
+            "inset-y-0 -right-12 my-auto",
+            "cn-context-menu-content-aria cn-menu-target cn-menu-translucent cn-menu-translucent-aria z-50 w-(--trigger-width) origin-(--trigger-anchor-point) overflow-x-hidden overflow-y-auto outline-none data-exiting:overflow-hidden"
+          ],
+          "ghost": "cn-command-group"
+        }
+      }
+    }
+  },
+  {
+    "base": "icon",
+    "config": {
+      "variants": {
+        "align": {
+          "secondary": "cn-alert-description [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground",
+          "primary": "cn-dialog-overlay fixed inset-0 isolate z-50"
+        }
+      },
+      "defaultVariants": { "align": "secondary" }
+    }
+  },
+  {
+    "base": "cn-combobox-item-indicator-icon pointer-events-none",
+    "config": {
+      "variants": {
+        "disabled": {
+          "true": "bg-sky-600 text-sky-50 dark:bg-sky-600 dark:text-sky-50",
+          "false": "aspect-square w-full rounded-sm object-cover"
+        },
+        "align": {
+          "secondary": "border-ghost w-full flex-1 rounded-md bg-(--bg) after:rounded-lg after:border-input md:rounded-lg",
+          "ghost": "absolute inset-0 flex items-center justify-center pb-4"
+        }
+      },
+      "defaultVariants": { "align": "ghost" }
+    }
+  },
+  {
+    "base": "cn-accordion-item",
+    "config": {
+      "variants": {
+        "loading": {
+          "true": "-mx-4 w-[140vw] overflow-hidden md:hidden",
+          "false": "absolute inset-y-0 right-0 left-62 z-40 bg-transparent"
+        },
+        "size": {
+          "default": "absolute inset-x-0 bottom-0 z-20 h-80 bg-linear-to-t from-background via-muted to-transparent dark:via-muted/30",
+          "outline": "cn-attachment group/attachment relative flex max-w-full min-w-0 shrink-0 flex-wrap border bg-card text-card-foreground transition-colors has-[>a,>button]:hover:bg-muted/50 data-[state=error]:border-destructive/30 data-[state=idle]:border-dashed"
+        },
+        "orientation": { "secondary": "**:[.preview]:h-[560px]" }
+      },
+      "defaultVariants": { "size": "default" }
+    }
+  },
+  {
+    "base": "cn-button-variant-ghost",
+    "config": {
+      "variants": {
+        "side": {
+          "secondary": "block size-4 shrink-0 rounded-full border border-primary bg-white shadow-sm ring-ring/50 transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50",
+          "ghost": "cn-bubble-variant-ghost",
+          "md": [
+            "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+            "cn-breadcrumb-separator"
+          ]
+        }
+      }
+    }
+  },
+  {
+    "base": ["cn-alert-dialog-media", "cn-breadcrumb-separator"],
+    "config": {
+      "variants": {
+        "color": {
+          "primary": "peer-data-[size=sm]/menu-button:top-1",
+          "outline": "cn-button-group-orientation-vertical flex-col **:data-slot:rounded-b-none [&_[data-slot]~[data-slot]]:rounded-t-none [&_[data-slot]~[data-slot]]:border-t-0",
+          "secondary": "bg-[Canvas] text-[CanvasText]"
+        },
+        "align": {
+          "primary": [
+            "[&>*:not(:first-child)]:rounded-l-none [&>*:not(:first-child)]:border-l-0 [&>*:not(:last-child)]:rounded-r-none",
+            "cn-attachment-description block min-w-0 truncate text-muted-foreground group-data-[state=error]/attachment:text-destructive/80"
+          ],
+          "outline": [
+            "group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 peer-data-[active=true]/menu-button:text-sidebar-accent-foreground data-[state=open]:opacity-100 md:opacity-0",
+            "cn-combobox-item-indicator-icon pointer-events-none"
+          ],
+          "ghost": "aria-expanded:text-destructive"
+        }
+      }
+    }
+  },
+  {
+    "base": "absolute top-[0px] left-[122px] z-10 text-sm font-medium",
+    "config": {
+      "variants": {
+        "tone": {
+          "secondary": "bottom",
+          "ghost": "peer-data-[size=lg]/menu-button:top-2.5"
+        }
+      }
+    }
+  }
+]

--- a/packages/conformance/package.json
+++ b/packages/conformance/package.json
@@ -4,9 +4,10 @@
   "description": "Reference oracles and gates for cn: differential parity suites vs tailwind-merge + clsx, benchmark matrix vs the incumbents, bundle-size gate, and the vendored-config source of truth. Never published.",
   "type": "module",
   "scripts": {
-    "test": "node tests/correctness.mjs && node tests/fuzz.mjs && node tests/custom-config.mjs && node tests/cli.mjs && node tests/hardening.mjs && node tests/bounds.mjs && node tests/join.mjs",
+    "test": "node tests/correctness.mjs && node tests/fuzz.mjs && node tests/custom-config.mjs && node tests/cva.mjs && node tests/cli.mjs && node tests/hardening.mjs && node tests/bounds.mjs && node tests/join.mjs",
     "test:src": "node tests/correctness.mjs --src && node tests/fuzz.mjs --src",
     "bench": "node bench/bench.mjs",
+    "bench:cva": "node bench/cva.mjs",
     "bench:corpus": "node bench/corpus.mjs",
     "size": "node scripts/size.mjs",
     "vendor-config": "node scripts/vendor-config.mjs",
@@ -16,6 +17,7 @@
     "cn": "workspace:*"
   },
   "devDependencies": {
+    "class-variance-authority": "0.7.1",
     "clsx": "^2.1.1",
     "cnfast": "0.2.0",
     "esbuild": "^0.25.0",

--- a/packages/conformance/scripts/size.mjs
+++ b/packages/conformance/scripts/size.mjs
@@ -40,6 +40,13 @@ const rows = [
     `import { clsx } from 'clsx'; import { twMerge } from 'tailwind-merge'; export const cn = (...a) => twMerge(clsx(a))`
   ),
   await measure("cnfast", `export { cn } from 'cnfast'`),
+  await measure("cn (root cva)", `export { cva } from 'cn'`),
+  await measure("cn/cva", `export { cva } from 'cn/cva'`),
+  await measure(
+    "class-variance-authority",
+    `export { cva } from 'class-variance-authority'`
+  ),
+  await measure("cnfast (cva only)", `export { cva } from 'cnfast'`),
 ]
 for (const r of rows)
   console.log(

--- a/packages/conformance/tests/cva.mjs
+++ b/packages/conformance/tests/cva.mjs
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import {
+  cva as referenceCva,
+  cx as referenceCx,
+} from "class-variance-authority"
+import { cva, cx } from "cn"
+import { cva as subpathCva } from "cn/cva"
+
+const sites = JSON.parse(
+  readFileSync(new URL("../bench/cva/cva-sites.json", import.meta.url), "utf8")
+)
+const calls = JSON.parse(
+  readFileSync(new URL("../bench/cva/cva-calls.json", import.meta.url), "utf8")
+)
+
+let checked = 0
+const same = (actual, expected, label) => {
+  checked++
+  assert.equal(actual, expected, label)
+}
+
+same(cx("a", ["b", { c: true }]), referenceCx("a", ["b", { c: true }]), "cx")
+same(
+  subpathCva("a", { variants: { tone: { calm: "b" } } })({ tone: "calm" }),
+  "a b",
+  "cva subpath"
+)
+
+const ours = sites.map(({ base, config }) => cva(base, config ?? undefined))
+const theirs = sites.map(({ base, config }) =>
+  referenceCva(base, config ?? undefined)
+)
+
+let seed = 0xc4abe4c
+const random = () => {
+  seed ^= seed << 13
+  seed >>>= 0
+  seed ^= seed >> 17
+  seed ^= seed << 5
+  seed >>>= 0
+  return seed / 0x100000000
+}
+const shuffledIndices = (length) => {
+  const indices = Array.from({ length }, (_, index) => index)
+  for (let index = length - 1; index > 0; index--) {
+    const other = Math.floor(random() * (index + 1))
+    const value = indices[index]
+    indices[index] = indices[other]
+    indices[other] = value
+  }
+  return indices
+}
+
+const verifyRow = (row, label) => {
+  const props = row.length === 2 ? row[1] : undefined
+  same(ours[row[0]](props), theirs[row[0]](props), label)
+}
+
+for (let pass = 0; pass < 2; pass++) {
+  for (let index = 0; index < calls.length; index++) {
+    verifyRow(calls[index], `dataset fixed pass ${pass} call ${index}`)
+  }
+}
+for (let pass = 0; pass < 3; pass++) {
+  const order = shuffledIndices(calls.length)
+  for (const index of order) {
+    verifyRow(calls[index], `dataset shuffled pass ${pass} call ${index}`)
+  }
+}
+
+const buttonConfig = {
+  variants: {
+    intent: {
+      primary: "bg-blue-600 text-white",
+      secondary: "bg-white text-gray-900",
+      danger: "bg-red-600 text-white",
+    },
+    size: { small: "px-2 py-1", medium: "px-3 py-2", large: "px-4 py-3" },
+    disabled: {
+      true: "cursor-not-allowed opacity-50",
+      false: "cursor-pointer",
+    },
+  },
+  compoundVariants: [
+    { intent: "primary", size: "large", class: "uppercase" },
+    { intent: ["danger", "secondary"], disabled: false, className: "shadow" },
+    { disabled: true, class: "select-none" },
+  ],
+  defaultVariants: { intent: "primary", size: "medium", disabled: false },
+}
+const memoOurs = cva("button rounded", buttonConfig)
+const memoTheirs = referenceCva("button rounded", buttonConfig)
+const intents = ["primary", "secondary", "danger", null, undefined]
+const sizes = ["small", "medium", "large", null, undefined]
+const disabledValues = [true, false, null, undefined]
+for (let pass = 0; pass < 4; pass++) {
+  let combination = 0
+  for (const intent of intents) {
+    for (const size of sizes) {
+      for (const disabled of disabledValues) {
+        const props = {
+          intent,
+          size,
+          disabled,
+          className:
+            combination++ % 3 === 0 ? `adhoc-${combination}` : undefined,
+        }
+        same(
+          memoOurs(props),
+          memoTheirs(props),
+          `memo combination ${combination}`
+        )
+      }
+    }
+  }
+}
+
+const mutableClass = { underline: true }
+const mutableProps = { intent: "secondary", className: mutableClass }
+same(memoOurs(mutableProps), memoTheirs(mutableProps), "mutable class before")
+mutableClass.underline = false
+same(memoOurs(mutableProps), memoTheirs(mutableProps), "mutable class after")
+
+const wideVariants = {}
+for (let index = 0; index < 20; index++) {
+  wideVariants[`variant${index}`] = {
+    on: `variant-${index}-on`,
+    off: `variant-${index}-off`,
+  }
+}
+const wideOurs = cva("wide", { variants: wideVariants })
+const wideTheirs = referenceCva("wide", { variants: wideVariants })
+for (let pass = 0; pass < 40; pass++) {
+  const props = {
+    variant0: pass % 2 ? "on" : "off",
+    variant7: pass % 3 ? "off" : "on",
+    variant19: "on",
+  }
+  same(wideOurs(props), wideTheirs(props), `wide config ${pass}`)
+}
+
+console.log(`cva: pass ${checked}  fail 0`)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
         specifier: workspace:*
         version: link:../cn
     devDependencies:
+      class-variance-authority:
+        specifier: 0.7.1
+        version: 0.7.1
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -659,6 +662,9 @@ packages:
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
+
+  class-variance-authority@0.7.1:
+    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -1640,6 +1646,10 @@ snapshots:
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
+
+  class-variance-authority@0.7.1:
+    dependencies:
+      clsx: 2.1.1
 
   clsx@2.1.1: {}
 


### PR DESCRIPTION
## Summary

This PR ports the compiled `cva` resolver from [`aidenybai/cnfast`](https://github.com/aidenybai/cnfast). It keeps byte-level output and public type compatibility with `class-variance-authority` 0.7.1 for normal plain-object props.

- Export `cva`, `cx`, and the CVA public types from `cn`.
- Add `cn/cva` for applications that only need the variant resolver. This entry does not include the Tailwind merge engine.
- Port the 48-site, 1,152-call replay data and its fixed, shuffled, cache-churn, compound, mutable-class, and composite benchmark cases.
- Add differential output tests, ESM and CJS declaration tests, size measurements, migration docs, and a minor changeset.

## Implementation

The resolver compiles each configuration on its first call. It resolves static class values once, then uses bounded fast paths for repeat calls:

- A dense combination table handles small variant spaces without compound variants.
- A four-slot lane handles configurations with up to two prop names.
- A bounded ring handles wider configurations and compound variants.
- Calls with mutable object or array values do not use an unsafe cached result.

The configuration must stay unchanged after the first call. Props must be normal plain objects. Inherited and non-enumerable props are outside the compatibility target.

## Performance

These results are from the committed replay benchmark. They are synthetic proxy workloads. They are not an overall application speed claim.

Method:

- Apple M5 Max, macOS arm64.
- `class-variance-authority` 0.7.1 and `cnfast` 0.2.0.
- One child process for each implementation and scenario.
- 30 warm-up passes, 40 timed passes per sample, and the best of 15 samples.
- 48 generated sites and 1,152 replay calls for the realistic rows.
- Lower time is better. A value above `1.00x` means this PR is faster.

Representative Node 22.23.2 results:

| Scenario | `cn` | CVA 0.7.1 | `cnfast` | vs CVA | vs `cnfast` |
| --- | ---: | ---: | ---: | ---: | ---: |
| Create resolver | 11.0 ns | 11.6 ns | 10.9 ns | 1.05x | 0.99x |
| Realistic mix, fixed | 29.4 ns | 171.7 ns | 28.8 ns | 5.85x | 0.98x |
| Realistic mix, shuffled | 40.9 ns | 196.0 ns | 41.2 ns | 4.79x | 1.01x |
| All defaults / no argument | 3.1 ns | 102.6 ns | 3.1 ns | 32.93x | 1.00x |
| shadcn steady state | 14.8 ns | 138.1 ns | 14.0 ns | 9.36x | 0.95x |
| Memo miss churn, fixed | 16.5 ns | 154.2 ns | 18.4 ns | 9.34x | 1.11x |
| Memo miss churn, shuffled | 22.6 ns | 161.8 ns | 23.4 ns | 7.17x | 1.04x |
| Compound heavy | 49.0 ns | 1.94 us | 49.2 ns | 39.60x | 1.00x |
| Mutable object `className` | 50.0 ns | 187.2 ns | 48.6 ns | 3.74x | 0.97x |
| `cn(cva(props))` | 45.0 ns | 496.7 ns | 45.1 ns | 11.03x | 1.00x |

The geometric mean across the nine call scenarios, without resolver creation, was:

| Runtime | vs CVA 0.7.1 | vs `cnfast` |
| --- | ---: | ---: |
| Node 20.20.2 | 10.19x | 1.04x |
| Node 22.23.2 | 9.94x | 1.01x |
| Node 24.20.0 | 8.35x | 1.00x |

The call path is consistently faster than CVA 0.7.1 in this replay. Resolver creation is close to equal. Results against `cnfast` are close to equal, as expected for a port. Individual rows can move in either direction. For example, Node 24 fixed memo churn was 0.87x versus `cnfast`, while the nine-row geometric mean was 1.00x.

Run the benchmark with:

```sh
pnpm bench:cva
```

## Bundle size

The size script bundles and minifies each named export with esbuild, then uses gzip level 9.

| Import | Minified | Minified + gzip |
| --- | ---: | ---: |
| `cva` from `cn/cva` | 5,255 B | 2,003 B |
| `cva` from `cn` | 32,661 B | 12,628 B |
| `class-variance-authority` | 1,011 B | 548 B |
| `cva` from `cnfast` | 45,085 B | 15,553 B |

The optimized resolver costs 1,455 more gzip bytes than CVA 0.7.1. The `cn/cva` entry is 87.1% smaller after gzip than the `cnfast` root export. The root `cn` import includes the merge engine, so CVA-only users should use `cn/cva`.

The normal tree-shaken `cn` bundle changed from 10,803 to 10,804 minified + gzip bytes. The merge engine output is byte-identical to `main`, and the existing benchmark did not show a consistent call-path change.

## Correctness and checks

- 6,204 CVA differential and focused checks pass with zero output differences.
- The replay runs in fixed and seeded shuffled orders to exercise the memo paths.
- Mutable object class values, wide configurations, compound variants, Boolean variants, `class`, and `className` are covered.
- Root and `cn/cva` types resolve through both ESM `.d.ts` and CommonJS `.d.cts` exports.
- The full existing conformance suite still passes.

Commands run:

```sh
pnpm lint
pnpm typecheck
pnpm test
pnpm size
pnpm format:check
npx -y node@20 packages/conformance/bench/cva.mjs
npx -y node@22 packages/conformance/bench/cva.mjs
npx -y node@24 packages/conformance/bench/cva.mjs
```
