### PR TITLE
feat: add cn/build entry

### DIFF
--- a/.changeset/cn-build-entry.md
+++ b/.changeset/cn-build-entry.md
@@ -1,0 +1,5 @@
+---
+"cn": minor
+---
+
+Add `cn/build`, the library behind `cn build`. The CLI now parses arguments and prints; scanning, subsetting, compiling, and writing run in `build(options)` so build scripts and bundler plugins can call it directly.

--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ Every export maps to the same name or a familiar one:
 - **`cn/engine`**: `createCn(tables, ...)`, `createEngine(tables, ...)` for
   build-time compiled tables
 - **`cn/lite`**: `clsx(...)`, strings-only join (`clsx/lite` parity)
+- **`cn/build`**: `build(options)`, the library behind the CLI, for custom
+  pipelines and bundler plugins
 - **CLI**: `npx cn build --help`
 
 ## Credits

--- a/docs/build-setup.md
+++ b/docs/build-setup.md
@@ -114,6 +114,30 @@ output — so it caches cleanly:
 }
 ```
 
+## From a script
+
+`cn/build` is the function the CLI calls. Use it when a shell step doesn't
+fit: a custom build script, a bundler plugin, a monorepo task runner that
+wants a JavaScript API. Every CLI option is a field with the same name, and
+errors throw with the message the CLI would print.
+
+```ts
+import { build } from "cn/build"
+
+const result = await build({
+  cwd: process.cwd(),
+  content: ["src/**/*.{ts,tsx}"],
+  out: "src/lib/cn-tables.ts",
+})
+
+console.log(`${result.usedGroups}/${result.totalGroups} class groups kept`)
+for (const warning of result.warnings) console.warn(warning)
+```
+
+The result carries the written path, the emitted source, the candidate
+tokens the tables were fitted to, and the group counts, so a caller can log,
+cache, or decide when to rebuild.
+
 ## Custom themes
 
 Add `--config` to the same command and the theme is baked into the generated

--- a/packages/cn/bin/cn.mjs
+++ b/packages/cn/bin/cn.mjs
@@ -9,21 +9,9 @@
 //   npx cn build --full                           skip subsetting (all groups; custom config still applies)
 //   npx cn build --tokens tokens.txt              use a pre-extracted token file instead of scanning
 //
-// Subsetting contract (same as Tailwind's content scanning): every class that
-// appears in the scanned sources merges byte-identically to the full tables;
-// classes never seen in your sources may instead pass through unmerged — they
-// have no CSS in your build anyway. Don't build class names by string
-// concatenation, or add them to the safelist if you must.
-import {
-  mkdirSync,
-  readdirSync,
-  readFileSync,
-  realpathSync,
-  statSync,
-  writeFileSync,
-} from "node:fs"
-import { basename, dirname, join, resolve, sep } from "node:path"
-import { pathToFileURL } from "node:url"
+// This file only parses arguments and prints. The work is `build()` from
+// "cn/build", which bundler plugins call directly.
+import { readFileSync } from "node:fs"
 import { gzipSync } from "node:zlib"
 
 const args = process.argv.slice(2)
@@ -66,9 +54,9 @@ if (args[0] !== "build") fail(`unknown command "${args[0]}" (expected: build)`)
 const opts = {
   content: [],
   out: "cn-tables.mjs",
-  safelist: null,
-  config: null,
-  tokens: null,
+  safelist: undefined,
+  config: undefined,
+  tokens: undefined,
   full: false,
   cwd: process.cwd(),
   quiet: false,
@@ -109,301 +97,29 @@ for (let i = 1; i < args.length; i++) {
   else fail(`unknown option "${a}"`)
 }
 
-const outPath = resolve(opts.cwd, opts.out)
-const realpathOrNull = (path) => {
-  try {
-    return realpathSync(path)
-  } catch {
-    return null
-  }
-}
+const { build } = await import("../dist/build.js")
 
-// ---- mini-glob: pattern → {base, regex}; recursive walk, no deps ------------
-const globToRegex = (pattern) => {
-  let re = ""
-  for (let i = 0; i < pattern.length; i++) {
-    const c = pattern[i]
-    if (c === "*") {
-      if (pattern[i + 1] === "*") {
-        // '**' (+ optional '/') matches any depth including none
-        re += "(?:.*)"
-        i++
-        if (pattern[i + 1] === "/") {
-          re += "/?"
-          i++
-        }
-      } else re += "[^/]*"
-    } else if (c === "?") re += "[^/]"
-    else if (c === "{") {
-      const end = pattern.indexOf("}", i)
-      if (end === -1) fail("unclosed { in glob: " + pattern)
-      re +=
-        "(?:" +
-        pattern
-          .slice(i + 1, end)
-          .split(",")
-          .map((s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
-          .join("|") +
-        ")"
-      i = end
-    } else if (".+^$()|[]\\".includes(c)) re += "\\" + c
-    else re += c
-  }
-  return new RegExp("^" + re + "$")
-}
-const IGNORED_DIRS = new Set([
-  "node_modules",
-  ".git",
-  "dist",
-  "build",
-  ".next",
-  ".nuxt",
-  "out",
-  "coverage",
-  ".svelte-kit",
-  ".astro",
-  ".vercel",
-  ".output",
-])
-// Literal leading path of a glob: the segments before the first one that
-// contains a glob character. "src/**/*.ts" → "src"; "**/*.ts" → "".
-const literalPrefix = (pattern) => {
-  const segs = pattern.split("/")
-  const keep = []
-  for (const s of segs) {
-    if (/[*?{]/.test(s)) break
-    keep.push(s)
-  }
-  return keep.join("/")
-}
-
-const scanState = { skippedUnreadable: 0, skippedLong: 0 }
-
-// Walk `dir` (relative path `rel` from cwd), appending relative file paths.
-// `optIn` holds literal prefixes from the patterns; a normally-pruned
-// directory is entered when some prefix equals or descends into it.
-// Symlinks are followed via statSync; `ancestors` holds the real paths of
-// dir's own ancestors in the current recursion branch (added before, and
-// removed after, walking a directory's children), so a symlink pointing
-// back at one of its ancestors is caught as a cycle without also blocking
-// a legitimate second visit to the same real directory from an unrelated
-// branch (e.g. a symlink next to the directory it targets).
-const walk = (dir, rel, out, optIn, ancestors) => {
-  let real
-  try {
-    real = realpathSync(dir)
-  } catch {
-    scanState.skippedUnreadable++
-    return
-  }
-  if (ancestors.has(real)) return
-  ancestors.add(real)
-  let entries
-  try {
-    entries = readdirSync(dir, { withFileTypes: true })
-  } catch {
-    scanState.skippedUnreadable++
-    ancestors.delete(real)
-    return
-  }
-  for (const e of entries) {
-    const childRel = rel ? rel + "/" + e.name : e.name
-    const childAbs = join(dir, e.name)
-    let isDir = e.isDirectory()
-    let isFile = e.isFile()
-    if (e.isSymbolicLink()) {
-      try {
-        const st = statSync(childAbs)
-        isDir = st.isDirectory()
-        isFile = st.isFile()
-      } catch {
-        continue
-      }
-    }
-    if (isDir) {
-      if (e.name === ".git") continue
-      const pruned = IGNORED_DIRS.has(e.name) || e.name.startsWith(".")
-      if (
-        pruned &&
-        !optIn.some((p) => p === childRel || p.startsWith(childRel + "/"))
-      )
-        continue
-      walk(childAbs, childRel, out, optIn, ancestors)
-    } else if (isFile) {
-      out.push(childRel)
-    }
-  }
-  ancestors.delete(real)
-}
-const expandGlobs = (patterns, cwd) => {
-  const files = new Set()
-  let allFiles = null
-  const optIn = patterns
-    .map((raw) => literalPrefix(raw.replace(/\\/g, "/").replace(/^\.\//, "")))
-    .filter(Boolean)
-  for (const raw of patterns) {
-    const pattern = raw.replace(/\\/g, "/").replace(/^\.\//, "")
-    if (!/[*?{]/.test(pattern)) {
-      // literal path: file or directory
-      const p = resolve(cwd, pattern)
-      let st
-      try {
-        st = statSync(p)
-      } catch {
-        continue
-      }
-      if (st.isFile()) files.add(p)
-      else if (st.isDirectory()) {
-        const sub = []
-        walk(p, "", sub, [], new Set())
-        for (const f of sub) files.add(join(p, f.split("/").join(sep)))
-      }
-      continue
-    }
-    if (allFiles === null) {
-      allFiles = []
-      walk(cwd, "", allFiles, optIn, new Set())
-    }
-    const re = globToRegex(pattern)
-    for (const f of allFiles)
-      if (re.test(f)) files.add(resolve(cwd, f.split("/").join(sep)))
-  }
-  return [...files]
-}
-
-// ---- candidate extraction (over-approximation is safe: unknown tokens only
-// classify as "not a Tailwind class"; missing tokens are the danger) ---------
-const CANDIDATE_RE = /[^<>"'`\s]*[^<>"'`\s:]/g
-const extractTokens = (text, into) => {
-  const matches = text.match(CANDIDATE_RE)
-  if (!matches) return
-  for (const m of matches) {
-    if (m.length === 0) continue
-    if (m.length > 8192) {
-      scanState.skippedLong++
-      continue
-    }
-    into.add(m)
-  }
-}
-
-// ---- main --------------------------------------------------------------------
-const { compileToSource, subsetConfig, mergeConfigs } =
-  await import("../dist/compiler.js")
-const { defaultConfig } = await import("../dist/config.js")
-
-let config = defaultConfig()
-if (opts.config) {
-  let mod
-  try {
-    mod = await import(pathToFileURL(resolve(opts.cwd, opts.config)).href)
-  } catch (err) {
-    fail(`cannot load config ${opts.config}: ${err.message}`)
-  }
-  const ext = mod.default ?? mod.config
-  if (!ext) fail(`config file ${opts.config} has no default export`)
-  config = typeof ext === "function" ? ext(config) : mergeConfigs(config, ext)
-}
-
-const tokens = new Set()
-let scannedFiles = 0
-if (!opts.full) {
-  if (opts.tokens) {
-    let tokensText
-    try {
-      tokensText = readFileSync(resolve(opts.cwd, opts.tokens), "utf8")
-    } catch (err) {
-      fail(`cannot read tokens file ${opts.tokens}: ${err.message}`)
-    }
-    for (const t of tokensText.split(/\s+/)) {
-      if (t) tokens.add(t)
-    }
-  } else {
-    const patterns = opts.content.length
-      ? opts.content
-      : ["**/*.{js,jsx,ts,tsx,html,vue,svelte,astro,mdx}"]
-    // A previous output can also appear through a symlink in the content tree.
-    const outRealPath = realpathOrNull(outPath)
-    const files = expandGlobs(patterns, opts.cwd).filter(
-      (file) =>
-        file !== outPath &&
-        (outRealPath === null || realpathOrNull(file) !== outRealPath)
-    )
-    if (files.length === 0)
-      fail("no files matched the content globs; pass --content or use --full")
-    for (const f of files) {
-      try {
-        extractTokens(readFileSync(f, "utf8"), tokens)
-        scannedFiles++
-      } catch {
-        scanState.skippedUnreadable++
-      }
-    }
-    if (!opts.quiet) {
-      if (scanState.skippedUnreadable > 0)
-        console.error(
-          `cn: skipped ${scanState.skippedUnreadable} unreadable path(s)`
-        )
-      if (scanState.skippedLong > 0)
-        console.error(
-          `cn: skipped ${scanState.skippedLong} candidate token(s) longer than 8192 chars`
-        )
-    }
-  }
-  if (opts.safelist) {
-    let safelistText
-    try {
-      safelistText = readFileSync(resolve(opts.cwd, opts.safelist), "utf8")
-    } catch (err) {
-      fail(`cannot read safelist ${opts.safelist}: ${err.message}`)
-    }
-    for (const t of safelistText.split(/\s+/)) {
-      if (t) tokens.add(t)
-    }
-  }
-}
-
-let usedGroups = null
-let totalGroups = null
-if (!opts.full) {
-  const r = subsetConfig(config, tokens)
-  config = r.config
-  usedGroups = r.usedGroups
-  totalGroups = r.totalGroups
-}
-
-const lang = outPath.endsWith(".ts") ? "ts" : "js"
-const banner = `// GENERATED by \`cn build\` — do not edit.
-// Pair with createCn from "cn/engine":
-//   import tables from "./${basename(outPath)}"
-//   import { createCn } from "cn/engine"
-//   export const cn = createCn(tables)`
-let source
+let result
 try {
-  source = compileToSource(config, { lang, banner })
+  result = await build(opts)
 } catch (err) {
   fail(String(err && err.message ? err.message : err))
 }
-try {
-  mkdirSync(dirname(outPath), { recursive: true })
-  writeFileSync(outPath, source)
-} catch (err) {
-  fail(`cannot write ${opts.out}: ${err.message}`)
-}
 
 if (!opts.quiet) {
-  const gz = gzipSync(source, { level: 9 }).length
+  for (const w of result.warnings) console.error(`cn: ${w}`)
+  const gz = gzipSync(result.source, { level: 9 }).length
   const parts = []
   if (!opts.full) {
     parts.push(
-      `${scannedFiles ? `scanned ${scannedFiles} files, ` : ""}${tokens.size} candidate tokens`
+      `${result.scannedFiles ? `scanned ${result.scannedFiles} files, ` : ""}${result.tokens.size} candidate tokens`
     )
-    parts.push(`${usedGroups}/${totalGroups} class groups kept`)
+    parts.push(`${result.usedGroups}/${result.totalGroups} class groups kept`)
   } else {
     parts.push("all class groups kept (--full)")
   }
   console.log(`cn build: ${parts.join(", ")}`)
   console.log(
-    `  → ${opts.out} (${(source.length / 1024).toFixed(1)} KB source, ${(gz / 1024).toFixed(1)} KB gzip)`
+    `  → ${opts.out} (${(result.source.length / 1024).toFixed(1)} KB source, ${(gz / 1024).toFixed(1)} KB gzip)`
   )
 }

--- a/packages/cn/package.json
+++ b/packages/cn/package.json
@@ -61,6 +61,16 @@
         "default": "./dist/compiler.cjs"
       }
     },
+    "./build": {
+      "import": {
+        "types": "./dist/build.d.ts",
+        "default": "./dist/build.js"
+      },
+      "require": {
+        "types": "./dist/build.d.cts",
+        "default": "./dist/build.cjs"
+      }
+    },
     "./lite": {
       "import": {
         "types": "./dist/lite.d.ts",
@@ -96,6 +106,7 @@
     "merge"
   ],
   "devDependencies": {
+    "@types/node": "^20.19.43",
     "tsdown": "^0.12.0",
     "typescript": "^5.7.0"
   },

--- a/packages/cn/scripts/check-dts.mjs
+++ b/packages/cn/scripts/check-dts.mjs
@@ -43,6 +43,7 @@ import {
   type CompileStats, type CompiledTables, type EmitOptions, type SubsetResult,
 } from "cn/compiler"
 import liteDefault, { clsx as liteClsx } from "cn/lite"
+import { build, expandGlobs, extractTokens } from "cn/build"
 
 // clsx-style variadic signatures (0.2.1 published lite's clsx as \`(): string\`)
 const sigs: ((...inputs: ClassValue[]) => string)[] = [
@@ -100,6 +101,15 @@ void compileModel(merged)
 const stats: CompileStats = compileStats(merged)
 const subset: SubsetResult = subsetConfig(merged, ["p-2", "text-sm"])
 void [source, stats, subset]
+
+// build: the library behind the CLI
+const built: Promise<{ outPath: string; source: string; warnings: string[] }> =
+  build({ cwd: ".", content: ["src/**/*.{ts,tsx}"], out: "cn-tables.ts" })
+void build()
+void built
+const skipped: number = extractTokens("p-2 p-4", new Set<string>())
+const files: string[] = expandGlobs(["src/**/*.ts"], ".")
+void [skipped, files]
 
 // type-only exports stay importable from every entry that declares them
 const groupDef: ClassGroupDef = { $t: "spacing" }

--- a/packages/cn/src/build.ts
+++ b/packages/cn/src/build.ts
@@ -1,0 +1,383 @@
+// The library behind `cn build`: scan sources, subset the config, compile the
+// tables, and write the module. The CLI in bin/cn.mjs parses arguments and
+// prints; everything else lives here so bundler plugins can call it directly.
+//
+// Subsetting contract (same as Tailwind's content scanning): every class that
+// appears in the scanned sources merges byte-identically to the full tables;
+// classes never seen in your sources may instead pass through unmerged. They
+// have no CSS in your build anyway. Don't build class names by string
+// concatenation, or add them to the safelist if you must.
+import {
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+  writeFileSync,
+} from "node:fs"
+import { basename, dirname, join, resolve, sep } from "node:path"
+import { pathToFileURL } from "node:url"
+import { compileToSource, mergeConfigs, subsetConfig } from "./compiler"
+import { defaultConfig } from "./config"
+import type { CnConfig, ConfigExtension } from "./compiler"
+
+const DEFAULT_CONTENT = ["**/*.{js,jsx,ts,tsx,html,vue,svelte,astro,mdx}"]
+const DEFAULT_OUT = "cn-tables.mjs"
+const MAX_TOKEN_LENGTH = 8192
+
+const realpathOrNull = (path: string) => {
+  try {
+    return realpathSync(path)
+  } catch {
+    return null
+  }
+}
+
+// ---- mini-glob: pattern → regex; recursive walk, no deps --------------------
+const globToRegex = (pattern: string) => {
+  let re = ""
+  for (let i = 0; i < pattern.length; i++) {
+    const c = pattern[i]
+    if (c === "*") {
+      if (pattern[i + 1] === "*") {
+        // '**' (+ optional '/') matches any depth including none.
+        re += "(?:.*)"
+        i++
+        if (pattern[i + 1] === "/") {
+          re += "/?"
+          i++
+        }
+      } else re += "[^/]*"
+    } else if (c === "?") re += "[^/]"
+    else if (c === "{") {
+      const end = pattern.indexOf("}", i)
+      if (end === -1) throw new Error("unclosed { in glob: " + pattern)
+      re +=
+        "(?:" +
+        pattern
+          .slice(i + 1, end)
+          .split(",")
+          .map((s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+          .join("|") +
+        ")"
+      i = end
+    } else if (".+^$()|[]\\".includes(c)) re += "\\" + c
+    else re += c
+  }
+  return new RegExp("^" + re + "$")
+}
+
+const IGNORED_DIRS = new Set([
+  "node_modules",
+  ".git",
+  "dist",
+  "build",
+  ".next",
+  ".nuxt",
+  "out",
+  "coverage",
+  ".svelte-kit",
+  ".astro",
+  ".vercel",
+  ".output",
+])
+
+// Literal leading path of a glob: the segments before the first one that
+// contains a glob character. "src/**/*.ts" → "src"; "**/*.ts" → "".
+const literalPrefix = (pattern: string) => {
+  const segs = pattern.split("/")
+  const keep = []
+  for (const s of segs) {
+    if (/[*?{]/.test(s)) break
+    keep.push(s)
+  }
+  return keep.join("/")
+}
+
+// Walk `dir` (relative path `rel` from cwd), appending relative file paths.
+// `optIn` holds literal prefixes from the patterns; a normally-pruned
+// directory is entered when some prefix equals or descends into it.
+// Symlinks are followed via statSync; `ancestors` holds the real paths of
+// dir's own ancestors in the current recursion branch (added before, and
+// removed after, walking a directory's children), so a symlink pointing
+// back at one of its ancestors is caught as a cycle without also blocking
+// a legitimate second visit to the same real directory from an unrelated
+// branch (e.g. a symlink next to the directory it targets).
+const walk = (
+  dir: string,
+  rel: string,
+  out: string[],
+  optIn: string[],
+  ancestors: Set<string>,
+  state: { skippedUnreadable: number }
+) => {
+  let real
+  try {
+    real = realpathSync(dir)
+  } catch {
+    state.skippedUnreadable++
+    return
+  }
+  if (ancestors.has(real)) return
+  ancestors.add(real)
+  let entries
+  try {
+    entries = readdirSync(dir, { withFileTypes: true })
+  } catch {
+    state.skippedUnreadable++
+    ancestors.delete(real)
+    return
+  }
+  for (const e of entries) {
+    const childRel = rel ? rel + "/" + e.name : e.name
+    const childAbs = join(dir, e.name)
+    let isDir = e.isDirectory()
+    let isFile = e.isFile()
+    if (e.isSymbolicLink()) {
+      try {
+        const st = statSync(childAbs)
+        isDir = st.isDirectory()
+        isFile = st.isFile()
+      } catch {
+        continue
+      }
+    }
+    if (isDir) {
+      if (e.name === ".git") continue
+      const pruned = IGNORED_DIRS.has(e.name) || e.name.startsWith(".")
+      if (
+        pruned &&
+        !optIn.some((p) => p === childRel || p.startsWith(childRel + "/"))
+      )
+        continue
+      walk(childAbs, childRel, out, optIn, ancestors, state)
+    } else if (isFile) {
+      out.push(childRel)
+    }
+  }
+  ancestors.delete(real)
+}
+
+/**
+ * Expand content globs to absolute file paths. Patterns support `**`, `?`,
+ * and `{a,b}`; a pattern without glob characters is a literal file or
+ * directory. Ignored directories such as `node_modules` and dot-directories
+ * are entered only when a pattern names them.
+ */
+export const expandGlobs = (
+  patterns: readonly string[],
+  cwd: string,
+  state = { skippedUnreadable: 0 }
+) => {
+  const files = new Set<string>()
+  let allFiles: string[] | null = null
+  const optIn = patterns
+    .map((raw) => literalPrefix(raw.replace(/\\/g, "/").replace(/^\.\//, "")))
+    .filter(Boolean)
+  for (const raw of patterns) {
+    const pattern = raw.replace(/\\/g, "/").replace(/^\.\//, "")
+    if (!/[*?{]/.test(pattern)) {
+      // Literal path: file or directory.
+      const p = resolve(cwd, pattern)
+      let st
+      try {
+        st = statSync(p)
+      } catch {
+        continue
+      }
+      if (st.isFile()) files.add(p)
+      else if (st.isDirectory()) {
+        const sub: string[] = []
+        walk(p, "", sub, [], new Set(), state)
+        for (const f of sub) files.add(join(p, f.split("/").join(sep)))
+      }
+      continue
+    }
+    if (allFiles === null) {
+      allFiles = []
+      walk(cwd, "", allFiles, optIn, new Set(), state)
+    }
+    const re = globToRegex(pattern)
+    for (const f of allFiles)
+      if (re.test(f)) files.add(resolve(cwd, f.split("/").join(sep)))
+  }
+  return [...files]
+}
+
+// ---- candidate extraction (over-approximation is safe: unknown tokens only
+// classify as "not a Tailwind class"; missing tokens are the danger) ---------
+const CANDIDATE_RE = /[^<>"'`\s]*[^<>"'`\s:]/g
+
+/**
+ * Add every class-name candidate in `text` to `into`. Returns the number of
+ * candidates skipped for exceeding the length cap.
+ */
+export const extractTokens = (text: string, into: Set<string>) => {
+  const matches = text.match(CANDIDATE_RE)
+  if (!matches) return 0
+  let skippedLong = 0
+  for (const m of matches) {
+    if (m.length === 0) continue
+    if (m.length > MAX_TOKEN_LENGTH) {
+      skippedLong++
+      continue
+    }
+    into.add(m)
+  }
+  return skippedLong
+}
+
+const readText = (path: string, what: string, shown: string) => {
+  try {
+    return readFileSync(path, "utf8")
+  } catch (err) {
+    throw new Error(`cannot read ${what} ${shown}: ${(err as Error).message}`, {
+      cause: err,
+    })
+  }
+}
+
+const addWords = (text: string, into: Set<string>) => {
+  for (const t of text.split(/\s+/)) {
+    if (t) into.add(t)
+  }
+}
+
+const loadConfig = async (cwd: string, file: string) => {
+  let mod
+  try {
+    mod = await import(pathToFileURL(resolve(cwd, file)).href)
+  } catch (err) {
+    throw new Error(`cannot load config ${file}: ${(err as Error).message}`, {
+      cause: err,
+    })
+  }
+  const ext = mod.default ?? mod.config
+  if (!ext) throw new Error(`config file ${file} has no default export`)
+  return ext as ConfigExtension | ((config: CnConfig) => CnConfig)
+}
+
+/**
+ * Compile project-fitted merge tables and write them to `out`. This is what
+ * `cn build` runs. Throws on bad input with the same messages the CLI prints;
+ * non-fatal problems come back in `warnings`.
+ */
+export const build = async (
+  options: {
+    /** Base directory for every other path. Default: `process.cwd()`. */
+    cwd?: string
+    /** Source globs to scan. Default: `**\/*.{js,jsx,ts,tsx,html,vue,svelte,astro,mdx}`. */
+    content?: readonly string[]
+    /** Output module path. A `.ts` extension emits TypeScript. Default: `cn-tables.mjs`. */
+    out?: string
+    /** File of extra class names, whitespace-separated. */
+    safelist?: string
+    /** Config extension module: default export `{ extend, override, prefix }` or `(config) => config`. */
+    config?: string
+    /** File of pre-extracted tokens; skips scanning. */
+    tokens?: string
+    /** Keep every class group instead of subsetting to the scanned tokens. */
+    full?: boolean
+  } = {}
+) => {
+  const cwd = options.cwd ?? process.cwd()
+  const out = options.out ?? DEFAULT_OUT
+  const outPath = resolve(cwd, out)
+  const warnings: string[] = []
+
+  let config = defaultConfig()
+  if (options.config) {
+    const ext = await loadConfig(cwd, options.config)
+    config = typeof ext === "function" ? ext(config) : mergeConfigs(config, ext)
+  }
+
+  const tokens = new Set<string>()
+  let scannedFiles = 0
+  if (!options.full) {
+    if (options.tokens) {
+      addWords(
+        readText(resolve(cwd, options.tokens), "tokens file", options.tokens),
+        tokens
+      )
+    } else {
+      const patterns = options.content?.length
+        ? options.content
+        : DEFAULT_CONTENT
+      const state = { skippedUnreadable: 0 }
+      let skippedLong = 0
+      // A previous output can also appear through a symlink in the content tree.
+      const outRealPath = realpathOrNull(outPath)
+      const files = expandGlobs(patterns, cwd, state).filter(
+        (file) =>
+          file !== outPath &&
+          (outRealPath === null || realpathOrNull(file) !== outRealPath)
+      )
+      if (files.length === 0)
+        throw new Error(
+          "no files matched the content globs; pass --content or use --full"
+        )
+      for (const f of files) {
+        try {
+          skippedLong += extractTokens(readFileSync(f, "utf8"), tokens)
+          scannedFiles++
+        } catch {
+          state.skippedUnreadable++
+        }
+      }
+      if (state.skippedUnreadable > 0)
+        warnings.push(`skipped ${state.skippedUnreadable} unreadable path(s)`)
+      if (skippedLong > 0)
+        warnings.push(
+          `skipped ${skippedLong} candidate token(s) longer than ${MAX_TOKEN_LENGTH} chars`
+        )
+    }
+    if (options.safelist) {
+      addWords(
+        readText(resolve(cwd, options.safelist), "safelist", options.safelist),
+        tokens
+      )
+    }
+  }
+
+  let usedGroups: number | null = null
+  let totalGroups: number | null = null
+  if (!options.full) {
+    const r = subsetConfig(config, tokens)
+    config = r.config
+    usedGroups = r.usedGroups
+    totalGroups = r.totalGroups
+  }
+
+  const lang = outPath.endsWith(".ts") ? "ts" : "js"
+  const banner = `// GENERATED by \`cn build\` — do not edit.
+// Pair with createCn from "cn/engine":
+//   import tables from "./${basename(outPath)}"
+//   import { createCn } from "cn/engine"
+//   export const cn = createCn(tables)`
+  const source = compileToSource(config, { lang, banner })
+  try {
+    mkdirSync(dirname(outPath), { recursive: true })
+    writeFileSync(outPath, source)
+  } catch (err) {
+    throw new Error(`cannot write ${out}: ${(err as Error).message}`, {
+      cause: err,
+    })
+  }
+
+  return {
+    /** Absolute path of the written module. */
+    outPath,
+    /** The emitted module source. */
+    source,
+    /** Candidate tokens the subset was fitted to. Empty with `full`. */
+    tokens,
+    /** Files read during the scan. Zero with `tokens` or `full`. */
+    scannedFiles,
+    /** Class groups kept, or null with `full`. */
+    usedGroups,
+    /** Class groups in the config, or null with `full`. */
+    totalGroups,
+    /** Non-fatal problems, in the words the CLI prints. */
+    warnings,
+  }
+}

--- a/packages/cn/tsdown.config.ts
+++ b/packages/cn/tsdown.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     tables: "src/tables.generated.ts",
     config: "src/config.ts",
     compiler: "src/compiler.ts",
+    build: "src/build.ts",
     lite: "src/lite.ts",
   },
   format: ["esm", "cjs"],

--- a/packages/conformance/tests/cli.mjs
+++ b/packages/conformance/tests/cli.mjs
@@ -14,6 +14,7 @@ import {
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { fileURLToPath, pathToFileURL } from "node:url"
+import { build } from "cn/build"
 import { createCn } from "cn/engine"
 import { twMerge as ref } from "tailwind-merge"
 
@@ -322,6 +323,61 @@ try {
       readFileSync(join(selfDir, output), "utf8") ===
         readFileSync(join(selfDir, "expected", "cn-tables.ts"), "utf8")
     )
+  }
+
+  // ---- the library entry produces the same module as the CLI -----------------
+  {
+    const cli = run([
+      "build",
+      "--cwd",
+      dir,
+      "--content",
+      "src/**/*.{ts,tsx}",
+      "--safelist",
+      "safelist.txt",
+      "--config",
+      "cn.config.mjs",
+      "-o",
+      "t-cli.ts",
+      "-q",
+    ])
+    expect("lib-cli-exit", cli.status === 0, cli.stderr)
+    const lib = await build({
+      cwd: dir,
+      content: ["src/**/*.{ts,tsx}"],
+      safelist: "safelist.txt",
+      config: "cn.config.mjs",
+      out: "t-lib.ts",
+    })
+    expect(
+      "lib-parity",
+      readFileSync(join(dir, "t-cli.ts"), "utf8") ===
+        readFileSync(lib.outPath, "utf8").replace("t-lib.ts", "t-cli.ts")
+    )
+    expect("lib-result", lib.usedGroups > 0 && lib.usedGroups < lib.totalGroups)
+    expect(
+      "lib-tokens",
+      lib.tokens.has("columns-2") && lib.tokens.has("list-disc"),
+      [...lib.tokens].slice(0, 5).join(" ")
+    )
+    // The long arbitrary value in src/long.tsx is under the cap, so no warning.
+    expect(
+      "lib-no-warnings",
+      lib.warnings.length === 0,
+      lib.warnings.join("; ")
+    )
+    // Errors carry the message the CLI prints after its "cn: " prefix.
+    let message = ""
+    try {
+      await build({
+        cwd: dir,
+        content: ["nothing/**/*.zzz"],
+        out: "t-none.mjs",
+      })
+    } catch (err) {
+      message = err.message
+    }
+    expect("lib-throws", message.includes("no files matched"), message)
   }
 
   // ---- error paths use the cn: prefix and exit 1 ----------------------------

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
 
   packages/cn:
     devDependencies:
+      '@types/node':
+        specifier: ^20.19.43
+        version: 20.19.43
       tsdown:
         specifier: ^0.12.0
         version: 0.12.9(typescript@5.9.3)
@@ -556,6 +559,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@20.19.43':
+    resolution: {integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==}
 
   '@typescript-eslint/eslint-plugin@8.68.0':
     resolution: {integrity: sha512-WASHDpCm6qO5jj9g1a+8NiW5+GCkAyLReR56/4VruYmNgfUmqpxOfZ2Yfb8xGfJPWv5Qi6LSD8sXdces3vbp/Q==}
@@ -1076,6 +1082,9 @@ packages:
   unconfig@7.5.0:
     resolution: {integrity: sha512-oi8Qy2JV4D3UQ0PsopR28CzdQ3S/5A1zwsUwp/rosSbfhJ5z7b90bIyTwi/F7hCLD4SGcZVjDzd4XoUQcEanvA==}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
@@ -1513,6 +1522,10 @@ snapshots:
   '@types/estree@1.0.9': {}
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/node@20.19.43':
+    dependencies:
+      undici-types: 6.21.0
 
   '@typescript-eslint/eslint-plugin@8.68.0(@typescript-eslint/parser@8.68.0(eslint@10.9.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.9.1(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
@@ -2040,6 +2053,8 @@ snapshots:
       jiti: 2.7.0
       quansync: 1.0.0
       unconfig-core: 7.5.0
+
+  undici-types@6.21.0: {}
 
   uri-js@4.4.1:
     dependencies:


### PR DESCRIPTION
Add `cn/build`, the library behind `cn build`, so build scripts and bundler plugins can call it directly.