### PR TITLE
feat: add cn/vite and cn/next plugins

### DIFF
--- a/.changeset/cn-bundler-plugins.md
+++ b/.changeset/cn-bundler-plugins.md
@@ -1,0 +1,5 @@
+---
+"cn": minor
+---
+
+Add `cn/vite` and `cn/next`. The plugins generate project-fitted tables before the first module resolves and, in dev, regenerate them only when an edit uses a class group the current tables dropped. `build()` now leaves an identical output file untouched and reports `changed`, and `cn/build` gains `createBuilder` and `createContentMatcher` for other integrations.

--- a/.changeset/cn-bundler-plugins.md
+++ b/.changeset/cn-bundler-plugins.md
@@ -2,4 +2,4 @@
 "cn": minor
 ---
 
-Add `cn/vite` and `cn/next`. The plugins generate project-fitted tables before the first module resolves and, in dev, regenerate them only when an edit uses a class group the current tables dropped. `build()` now leaves an identical output file untouched and reports `changed`, and `cn/build` gains `createBuilder` and `createContentMatcher` for other integrations.
+Add `cn/vite` and `cn/next`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       - run: node packages/conformance/tests/default-config.mjs
       - run: node packages/conformance/tests/table-encoding.mjs
       - run: node packages/conformance/tests/cli.mjs
+      - run: node packages/conformance/tests/plugins.mjs
       - run: node packages/conformance/tests/hardening.mjs
       - run: node packages/conformance/tests/bounds.mjs
       - run: node packages/conformance/tests/join.mjs

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ per-repository table. Geometric mean across the 58 repositories: `cn` is
 
 If you want an even smaller bundle with the same performance, see
 [`cn build`](https://github.com/shadcn-ui/cn/blob/main/docs/build-setup.md).
+It ships as a Vite plugin and a Next.js config wrapper, so the tables follow
+your sources in dev with nothing to script.
 
 ## Custom themes
 
@@ -191,6 +193,7 @@ Every export maps to the same name or a familiar one:
 - **`cn/lite`**: `clsx(...)`, strings-only join (`clsx/lite` parity)
 - **`cn/build`**: `build(options)`, the library behind the CLI, for custom
   pipelines and bundler plugins
+- **`cn/vite`**: `cn(options)` plugin; **`cn/next`**: `withCn(nextConfig, options)`
 - **CLI**: `npx cn build --help`
 
 ## Credits

--- a/docs/build-setup.md
+++ b/docs/build-setup.md
@@ -53,7 +53,23 @@ followed.
 
 ## Next.js
 
-npm lifecycle hooks run automatically before `dev` and `build`:
+Wrap your config. The tables are generated when `next dev` or `next build`
+starts, before any module resolves, for webpack and Turbopack alike:
+
+```ts
+// next.config.ts
+import { withCn } from "cn/next"
+
+export default withCn(
+  { reactStrictMode: true },
+  { content: ["{app,components,lib}/**/*.{ts,tsx}"], out: "lib/cn-tables.ts" }
+)
+```
+
+A function config works too: `withCn(async (phase) => ({ ... }), options)`.
+
+If you'd rather not touch the config, npm lifecycle hooks do the same job
+before `dev` and `build`:
 
 ```jsonc
 // package.json
@@ -71,30 +87,33 @@ The `.ts` output typechecks like any source file.
 
 ## Vite
 
-Scripts work the same way, or fold it into the config so it can't be
-forgotten — regenerates on every dev-server start and build:
+Add the plugin next to Tailwind's. It generates the tables in `buildStart`,
+which runs on every dev-server start and every build:
 
 ```ts
 // vite.config.ts
-import { execSync } from "node:child_process"
+import tailwindcss from "@tailwindcss/vite"
+import { cn } from "cn/vite"
 import { defineConfig } from "vite"
 
-const cnBuild = () => ({
-  name: "cn-build",
-  buildStart() {
-    execSync(
-      "npx cn build --content 'src/**/*.{ts,tsx}' -o src/lib/cn-tables.js",
-      {
-        stdio: "inherit",
-      }
-    )
-  },
-})
-
 export default defineConfig({
-  plugins: [cnBuild()],
+  plugins: [
+    tailwindcss(),
+    cn({ content: ["src/**/*.{ts,tsx}"], out: "src/lib/cn-tables.ts" }),
+  ],
 })
 ```
+
+Options are the CLI flags by name. `cwd` defaults to Vite's `root`.
+
+## In dev
+
+Both plugins watch your sources. A save that only reuses classes the tables
+already know costs nothing. A save that introduces a class from a group the
+tables dropped regenerates the file, which is a normal module, so the code
+that imports it hot-reloads like any other edit. Deleting a file never
+triggers a rebuild, since tables fitted to more classes are still correct.
+Production builds always regenerate from scratch.
 
 ## Turborepo
 
@@ -156,8 +175,8 @@ export default {
 
 ## The one gap to know about
 
-If you add a class mid-dev-session from a group your project has never used
-before, stale tables pass it through unmerged until the next dev-server start
-(production builds are always in sync — the `prebuild` hook guarantees it).
-Restarting dev resyncs. The planned Vite/Next plugins close this by hooking
-the file watcher, the same way Tailwind's scanner does.
+With the npm-script setup, a class added mid-dev-session from a group your
+project has never used before passes through unmerged until the next
+dev-server start. Production builds are always in sync, since the `prebuild`
+hook guarantees it. The Vite and Next.js plugins close this by watching your
+sources, the same way Tailwind's scanner does.

--- a/packages/cn/package.json
+++ b/packages/cn/package.json
@@ -71,6 +71,26 @@
         "default": "./dist/build.cjs"
       }
     },
+    "./vite": {
+      "import": {
+        "types": "./dist/vite.d.ts",
+        "default": "./dist/vite.js"
+      },
+      "require": {
+        "types": "./dist/vite.d.cts",
+        "default": "./dist/vite.cjs"
+      }
+    },
+    "./next": {
+      "import": {
+        "types": "./dist/next.d.ts",
+        "default": "./dist/next.js"
+      },
+      "require": {
+        "types": "./dist/next.d.cts",
+        "default": "./dist/next.cjs"
+      }
+    },
     "./lite": {
       "import": {
         "types": "./dist/lite.d.ts",

--- a/packages/cn/scripts/check-dts.mjs
+++ b/packages/cn/scripts/check-dts.mjs
@@ -43,7 +43,11 @@ import {
   type CompileStats, type CompiledTables, type EmitOptions, type SubsetResult,
 } from "cn/compiler"
 import liteDefault, { clsx as liteClsx } from "cn/lite"
-import { build, expandGlobs, extractTokens } from "cn/build"
+import {
+  build, createBuilder, createContentMatcher, expandGlobs, extractTokens,
+} from "cn/build"
+import { cn as cnVite } from "cn/vite"
+import { withCn } from "cn/next"
 
 // clsx-style variadic signatures (0.2.1 published lite's clsx as \`(): string\`)
 const sigs: ((...inputs: ClassValue[]) => string)[] = [
@@ -110,6 +114,18 @@ void built
 const skipped: number = extractTokens("p-2 p-4", new Set<string>())
 const files: string[] = expandGlobs(["src/**/*.ts"], ".")
 void [skipped, files]
+const matches: (file: string) => boolean = createContentMatcher(["src/**"], ".")
+const builder = createBuilder({ content: ["src/**/*.tsx"] })
+const rebuilt: Promise<{ changed: boolean }> = builder.changed("src/a.tsx")
+void [matches, builder.run(), builder.last, rebuilt]
+
+// plugins: structural plugin objects, no bundler types required
+const vitePlugin: { name: string } = cnVite({ out: "src/lib/cn-tables.ts" })
+const nextConfig: (phase: string, context: unknown) => Promise<{ reactStrictMode: boolean }> =
+  withCn({ reactStrictMode: true }, { out: "lib/cn-tables.ts" })
+withCn(async () => ({ reactStrictMode: true }))
+withCn()
+void [vitePlugin, nextConfig]
 
 // type-only exports stay importable from every entry that declares them
 const groupDef: ClassGroupDef = { $t: "spacing" }

--- a/packages/cn/src/build.ts
+++ b/packages/cn/src/build.ts
@@ -15,7 +15,7 @@ import {
   statSync,
   writeFileSync,
 } from "node:fs"
-import { basename, dirname, join, resolve, sep } from "node:path"
+import { basename, dirname, join, relative, resolve, sep } from "node:path"
 import { pathToFileURL } from "node:url"
 import { compileToSource, mergeConfigs, subsetConfig } from "./compiler"
 import { defaultConfig } from "./config"
@@ -204,6 +204,47 @@ export const expandGlobs = (
   return [...files]
 }
 
+/**
+ * Build a predicate that tells whether an absolute path would be scanned by
+ * `expandGlobs` with the same patterns: it applies the same literal-path,
+ * glob, and ignored-directory rules without touching the filesystem.
+ */
+export const createContentMatcher = (
+  patterns: readonly string[],
+  cwd: string
+) => {
+  const normalized = patterns.map((raw) =>
+    raw.replace(/\\/g, "/").replace(/^\.\//, "")
+  )
+  const optIn = normalized.map(literalPrefix).filter(Boolean)
+  const literals = normalized.filter((p) => !/[*?{]/.test(p))
+  const regexes = normalized.filter((p) => /[*?{]/.test(p)).map(globToRegex)
+  const isPruned = (rel: string) => {
+    const segs = rel.split("/")
+    let path = ""
+    for (let i = 0; i < segs.length - 1; i++) {
+      const name = segs[i]
+      path = path ? path + "/" + name : name
+      if (name === ".git") return true
+      if (IGNORED_DIRS.has(name) || name.startsWith(".")) {
+        const dir = path
+        if (!optIn.some((p) => p === dir || p.startsWith(dir + "/")))
+          return true
+      }
+    }
+    return false
+  }
+  return (file: string) => {
+    const rel = relative(cwd, file).split(sep).join("/")
+    if (!rel || rel.startsWith("../") || rel === "..") return false
+    for (const lit of literals) {
+      if (rel === lit || rel.startsWith(lit + "/")) return true
+    }
+    if (isPruned(rel)) return false
+    return regexes.some((re) => re.test(rel))
+  }
+}
+
 // ---- candidate extraction (over-approximation is safe: unknown tokens only
 // classify as "not a Tailwind class"; missing tokens are the danger) ---------
 const CANDIDATE_RE = /[^<>"'`\s]*[^<>"'`\s:]/g
@@ -339,6 +380,7 @@ export const build = async (
     }
   }
 
+  const fullConfig = config
   let usedGroups: number | null = null
   let totalGroups: number | null = null
   if (!options.full) {
@@ -355,13 +397,23 @@ export const build = async (
 //   import { createCn } from "cn/engine"
 //   export const cn = createCn(tables)`
   const source = compileToSource(config, { lang, banner })
+  // Leave an identical module untouched so watchers and caches keyed on the
+  // file don't fire for a no-op rebuild.
+  let changed
   try {
-    mkdirSync(dirname(outPath), { recursive: true })
-    writeFileSync(outPath, source)
-  } catch (err) {
-    throw new Error(`cannot write ${out}: ${(err as Error).message}`, {
-      cause: err,
-    })
+    changed = readFileSync(outPath, "utf8") !== source
+  } catch {
+    changed = true
+  }
+  if (changed) {
+    try {
+      mkdirSync(dirname(outPath), { recursive: true })
+      writeFileSync(outPath, source)
+    } catch (err) {
+      throw new Error(`cannot write ${out}: ${(err as Error).message}`, {
+        cause: err,
+      })
+    }
   }
 
   return {
@@ -369,8 +421,14 @@ export const build = async (
     outPath,
     /** The emitted module source. */
     source,
+    /** False when the file already held this exact source and was left alone. */
+    changed,
     /** Candidate tokens the subset was fitted to. Empty with `full`. */
     tokens,
+    /** The config the tables were compiled from, after subsetting. */
+    config,
+    /** The config before subsetting, with any extension applied. */
+    fullConfig,
     /** Files read during the scan. Zero with `tokens` or `full`. */
     scannedFiles,
     /** Class groups kept, or null with `full`. */
@@ -379,5 +437,83 @@ export const build = async (
     totalGroups,
     /** Non-fatal problems, in the words the CLI prints. */
     warnings,
+  }
+}
+
+/**
+ * A `build()` that knows when to run again. `run()` builds, coalescing
+ * concurrent calls into one in-flight build plus at most one follow-up.
+ * `changed(file)` is for watchers: it rebuilds only when the file is inside
+ * the content globs and uses a class group the last build dropped.
+ * Deleted files never need a rebuild, since a subset fitted to more classes
+ * is still correct. With `full` or `tokens` the tables don't depend on
+ * sources, so `changed` never rebuilds.
+ */
+export const createBuilder = (options: Parameters<typeof build>[0] = {}) => {
+  const cwd = options.cwd ?? process.cwd()
+  const matches = createContentMatcher(
+    options.content?.length ? options.content : DEFAULT_CONTENT,
+    cwd
+  )
+  let last: Awaited<ReturnType<typeof build>> | null = null
+  let running: Promise<Awaited<ReturnType<typeof build>>> | null = null
+  let queued = false
+
+  const run = (): Promise<Awaited<ReturnType<typeof build>>> => {
+    if (running) {
+      queued = true
+      return running
+    }
+    running = build(options).then(
+      (result) => {
+        last = result
+        running = null
+        if (queued) {
+          queued = false
+          return run()
+        }
+        return result
+      },
+      (err) => {
+        running = null
+        queued = false
+        throw err
+      }
+    )
+    return running
+  }
+
+  const changed = async (file: string) => {
+    if (!last) return run()
+    if (options.full || options.tokens) return last
+    const abs = resolve(cwd, file)
+    if (abs === last.outPath || !matches(abs)) return last
+    let text
+    try {
+      text = readFileSync(abs, "utf8")
+    } catch {
+      return last
+    }
+    const fresh = new Set<string>()
+    extractTokens(text, fresh)
+    for (const t of last.tokens) fresh.delete(t)
+    if (fresh.size === 0) return last
+    // Classify only the unseen candidates. A class whose group the tables
+    // kept already merges correctly; one that reaches a dropped group means
+    // the subset no longer covers the sources.
+    const reached = subsetConfig(last.fullConfig, fresh).config.classGroups
+    for (const group in reached) {
+      if (!(group in last.config.classGroups)) return run()
+    }
+    return last
+  }
+
+  return {
+    run,
+    changed,
+    /** Result of the most recent completed build, or null before the first. */
+    get last() {
+      return last
+    },
   }
 }

--- a/packages/cn/src/next.ts
+++ b/packages/cn/src/next.ts
@@ -1,0 +1,31 @@
+// Next.js wrapper: next.config is evaluated once when `next dev` or
+// `next build` starts, for webpack and Turbopack alike, so generating the
+// tables there guarantees they exist before any module resolves.
+import { watch } from "node:fs"
+import { join } from "node:path"
+import { createBuilder } from "./build"
+
+export const withCn = <T extends object>(
+  nextConfig:
+    T | ((phase: string, context: unknown) => T | Promise<T>) = {} as T,
+  options: Parameters<typeof createBuilder>[0] = {}
+) => {
+  return async (phase: string, context: unknown) => {
+    const builder = createBuilder(options)
+    await builder.run()
+    if (phase === "phase-development-server") {
+      const cwd = options.cwd ?? process.cwd()
+      const report = (err: unknown) =>
+        console.error(`cn: ${err instanceof Error ? err.message : err}`)
+      // Recursive watching is native on macOS, Windows, and Linux from Node 20.
+      // The builder ignores paths outside the content globs, so watching the
+      // whole project is cheap.
+      watch(cwd, { recursive: true, persistent: false }, (_event, filename) => {
+        if (filename) builder.changed(join(cwd, filename)).catch(report)
+      })
+    }
+    return typeof nextConfig === "function"
+      ? nextConfig(phase, context)
+      : nextConfig
+  }
+}

--- a/packages/cn/src/vite.ts
+++ b/packages/cn/src/vite.ts
@@ -1,0 +1,22 @@
+// Vite plugin: generate project-fitted tables before the first module
+// resolves, and keep them fresh in dev. The generated file is a normal
+// module, so writing it is what triggers HMR for the code that imports it.
+import { createBuilder } from "./build"
+
+export const cn = (options: Parameters<typeof createBuilder>[0] = {}) => {
+  let builder: ReturnType<typeof createBuilder> | null = null
+  return {
+    name: "cn:build",
+    configResolved(config: { root: string }) {
+      builder = createBuilder({ cwd: config.root, ...options })
+    },
+    async buildStart() {
+      builder ??= createBuilder(options)
+      await builder.run()
+    },
+    async watchChange(id: string, change: { event: string }) {
+      if (change.event === "delete" || !builder) return
+      await builder.changed(id)
+    },
+  }
+}

--- a/packages/cn/tsdown.config.ts
+++ b/packages/cn/tsdown.config.ts
@@ -9,6 +9,8 @@ export default defineConfig({
     config: "src/config.ts",
     compiler: "src/compiler.ts",
     build: "src/build.ts",
+    vite: "src/vite.ts",
+    next: "src/next.ts",
     lite: "src/lite.ts",
   },
   format: ["esm", "cjs"],

--- a/packages/conformance/package.json
+++ b/packages/conformance/package.json
@@ -4,7 +4,7 @@
   "description": "Reference oracles and gates for cn: differential parity suites vs tailwind-merge + clsx, benchmark matrix vs the incumbents, bundle-size gate, and the vendored-config source of truth. Never published.",
   "type": "module",
   "scripts": {
-    "test": "node tests/correctness.mjs && node tests/fuzz.mjs && node tests/default-config.mjs && node tests/table-encoding.mjs && node tests/custom-config.mjs && node tests/cli.mjs && node tests/hardening.mjs && node tests/bounds.mjs && node tests/join.mjs",
+    "test": "node tests/correctness.mjs && node tests/fuzz.mjs && node tests/default-config.mjs && node tests/table-encoding.mjs && node tests/custom-config.mjs && node tests/cli.mjs && node tests/plugins.mjs && node tests/hardening.mjs && node tests/bounds.mjs && node tests/join.mjs",
     "test:src": "node tests/correctness.mjs --src && node tests/fuzz.mjs --src",
     "bench": "node bench/bench.mjs",
     "bench:corpus": "node bench/corpus.mjs",

--- a/packages/conformance/tests/plugins.mjs
+++ b/packages/conformance/tests/plugins.mjs
@@ -1,0 +1,247 @@
+// End-to-end tests for the builder and the bundler plugins: tables exist
+// before the first module resolves, an edit that only reuses known classes
+// leaves the file alone, and an edit that reaches a dropped class group
+// regenerates it. Plugin hooks are called directly with the shapes Vite and
+// Next.js pass, so no bundler is installed here.
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { pathToFileURL } from "node:url"
+import { cn as reference } from "cn"
+import { createBuilder, createContentMatcher } from "cn/build"
+import { createCn } from "cn/engine"
+import { withCn } from "cn/next"
+import { cn as cnVite } from "cn/vite"
+
+let pass = 0
+let fail = 0
+const expect = (label, cond, detail = "") => {
+  if (cond) pass++
+  else {
+    fail++
+    console.log(`PLUGINS FAIL [${label}] ${detail}`)
+  }
+}
+
+// Each fixture project gets its own directory and output file, and every
+// import of a generated module gets a cache-busting query so a rewritten
+// file is re-evaluated.
+let stamp = 0
+const project = (name) => {
+  const dir = mkdtempSync(join(tmpdir(), `cn-${name}-`))
+  mkdirSync(join(dir, "src", "lib"), { recursive: true })
+  writeFileSync(
+    join(dir, "src", "Button.tsx"),
+    `export const Button = () => <button className={cn("rounded-md px-4 py-2 text-sm bg-primary")} />`
+  )
+  return dir
+}
+const load = async (file) => {
+  const url = pathToFileURL(file).href + `?v=${++stamp}`
+  return createCn((await import(url)).default)
+}
+const settle = (ms) => new Promise((r) => setTimeout(r, ms))
+const waitFor = async (check, timeout = 4000) => {
+  const until = Date.now() + timeout
+  while (Date.now() < until) {
+    if (await check()) return true
+    await settle(50)
+  }
+  return check()
+}
+
+const dirs = []
+try {
+  // ---- content matcher mirrors the scanner's rules --------------------------
+  {
+    const cwd = "/proj"
+    const m = createContentMatcher(["src/**/*.{ts,tsx}", "out/**/*.html"], cwd)
+    expect("match-glob", m("/proj/src/ui/a.tsx"))
+    expect("match-ext", !m("/proj/src/ui/a.css"))
+    expect("match-outside", !m("/other/src/a.ts"))
+    expect("match-dotdir", !m("/proj/src/.cache/a.ts"))
+    expect("match-ignored", !m("/proj/src/node_modules/x/a.ts"))
+    expect("match-opt-in", m("/proj/out/index.html"))
+    const lit = createContentMatcher(["src", "cn.config.mjs"], cwd)
+    expect("match-literal-dir", lit("/proj/src/deep/a.vue"))
+    expect("match-literal-file", lit("/proj/cn.config.mjs"))
+    expect("match-literal-miss", !lit("/proj/lib/a.ts"))
+    const any = createContentMatcher(["**/*.tsx"], cwd)
+    expect("match-default-prunes", !any("/proj/node_modules/pkg/a.tsx"))
+    expect("match-default-root", any("/proj/a.tsx"))
+  }
+
+  // ---- builder: rebuild only when an edit reaches a dropped group ----------
+  {
+    const dir = project("builder")
+    dirs.push(dir)
+    const out = join(dir, "src", "lib", "cn-tables.mjs")
+    const builder = createBuilder({
+      cwd: dir,
+      content: ["src/**/*.{ts,tsx}"],
+      out: "src/lib/cn-tables.mjs",
+    })
+    expect("builder-before-run", builder.last === null)
+    const first = await builder.run()
+    expect("builder-writes", existsSync(out) && first.changed)
+    expect("builder-last", builder.last === first)
+    const merge1 = await load(out)
+    expect("builder-parity", merge1("px-4 px-2") === reference("px-4 px-2"))
+    expect(
+      "builder-subset",
+      merge1("list-disc list-none") === "list-disc list-none"
+    )
+
+    // Same classes again: no rebuild, and the file is untouched.
+    const mtime = statSync(out).mtimeMs
+    writeFileSync(
+      join(dir, "src", "Card.tsx"),
+      `export const Card = () => <div className={cn("px-4 text-sm")} />`
+    )
+    const same = await builder.changed(join(dir, "src", "Card.tsx"))
+    expect("builder-known-tokens-skip", same === first)
+    expect("builder-file-untouched", statSync(out).mtimeMs === mtime)
+
+    // Paths the scanner would not read never trigger a rebuild.
+    expect("builder-out-skip", (await builder.changed(out)) === first)
+    writeFileSync(join(dir, "README.md"), `list-disc`)
+    expect(
+      "builder-outside-globs-skip",
+      (await builder.changed(join(dir, "README.md"))) === first
+    )
+    expect(
+      "builder-missing-file-skip",
+      (await builder.changed(join(dir, "src", "gone.tsx"))) === first
+    )
+
+    // A new class group: rebuild, and the tables now merge it.
+    writeFileSync(
+      join(dir, "src", "List.tsx"),
+      `export const List = () => <ul className={cn("list-disc")} />`
+    )
+    const second = await builder.changed(join(dir, "src", "List.tsx"))
+    expect("builder-rebuilds", second !== first && second.changed)
+    const merge2 = await load(out)
+    expect(
+      "builder-new-group",
+      merge2("list-disc list-none") === reference("list-disc list-none"),
+      merge2("list-disc list-none")
+    )
+
+    // An identical rebuild reports no change and leaves the file alone.
+    const mtime2 = statSync(out).mtimeMs
+    const third = await builder.run()
+    expect("builder-unchanged", third.changed === false)
+    expect("builder-unchanged-file", statSync(out).mtimeMs === mtime2)
+
+    // Concurrent runs coalesce and resolve to the latest result.
+    const [a, b] = await Promise.all([builder.run(), builder.run()])
+    expect("builder-coalesce", a === b && builder.last === a)
+
+    // With --full the tables don't depend on sources.
+    const full = createBuilder({ cwd: dir, full: true, out: "full.mjs" })
+    const f1 = await full.run()
+    writeFileSync(join(dir, "src", "Z.tsx"), `"columns-2"`)
+    expect(
+      "builder-full-never-rebuilds",
+      (await full.changed(join(dir, "src", "Z.tsx"))) === f1
+    )
+
+    // Errors surface from run() and from changed().
+    let message = ""
+    try {
+      await createBuilder({ cwd: dir, content: ["nope/**"] }).run()
+    } catch (err) {
+      message = err.message
+    }
+    expect("builder-throws", message.includes("no files matched"), message)
+  }
+
+  // ---- vite plugin hooks ------------------------------------------------------
+  {
+    const dir = project("vite")
+    dirs.push(dir)
+    const out = join(dir, "src", "lib", "cn-tables.ts")
+    const plugin = cnVite({
+      content: ["src/**/*.{ts,tsx}"],
+      out: "src/lib/cn-tables.ts",
+    })
+    expect("vite-name", plugin.name === "cn:build")
+    plugin.configResolved({ root: dir })
+    await plugin.buildStart()
+    expect("vite-buildstart-writes", existsSync(out))
+    expect(
+      "vite-ts-output",
+      readFileSync(out, "utf8").includes("GENERATED by `cn build`")
+    )
+    const before = readFileSync(out, "utf8")
+    writeFileSync(
+      join(dir, "src", "Grid.tsx"),
+      `export const Grid = () => <div className={cn("columns-2")} />`
+    )
+    await plugin.watchChange(join(dir, "src", "Grid.tsx"), { event: "create" })
+    expect("vite-watchchange-rebuilds", readFileSync(out, "utf8") !== before)
+    await plugin.watchChange(join(dir, "src", "Grid.tsx"), { event: "delete" })
+    expect("vite-delete-ignored", existsSync(out))
+
+    // Without configResolved the plugin still works from the given cwd.
+    const bare = cnVite({ cwd: dir, out: "bare.mjs", full: true })
+    await bare.buildStart()
+    expect("vite-bare-cwd", existsSync(join(dir, "bare.mjs")))
+  }
+
+  // ---- next wrapper -----------------------------------------------------------
+  {
+    const dir = project("next")
+    dirs.push(dir)
+    const out = join(dir, "src", "lib", "cn-tables.ts")
+    const options = {
+      cwd: dir,
+      content: ["src/**/*.{ts,tsx}"],
+      out: "src/lib/cn-tables.ts",
+    }
+    const config = await withCn({ reactStrictMode: true }, options)(
+      "phase-production-build",
+      {}
+    )
+    expect("next-returns-config", config.reactStrictMode === true)
+    expect("next-build-writes", existsSync(out))
+
+    const fromFn = await withCn(async (phase) => ({ phase }), {
+      ...options,
+      out: "fn.mjs",
+    })("phase-production-build", {})
+    expect("next-function-config", fromFn.phase === "phase-production-build")
+    expect(
+      "next-default-config",
+      (await withCn(undefined, { cwd: dir, full: true, out: "d.mjs" })(
+        "phase-production-build",
+        {}
+      )) !== undefined
+    )
+
+    // Dev phase watches the project and regenerates on a reaching edit.
+    await withCn({}, options)("phase-development-server", {})
+    const before = readFileSync(out, "utf8")
+    await settle(100)
+    writeFileSync(
+      join(dir, "src", "Float.tsx"),
+      `export const Float = () => <div className={cn("float-left")} />`
+    )
+    const rebuilt = await waitFor(() => readFileSync(out, "utf8") !== before)
+    expect("next-dev-watch-rebuilds", rebuilt)
+  }
+} finally {
+  for (const d of dirs) rmSync(d, { recursive: true, force: true })
+}
+
+console.log(`plugins: pass ${pass}  fail ${fail}`)
+if (fail > 0) process.exit(1)


### PR DESCRIPTION
Add `cn/vite` and `cn/next` so the tables are generated before the first module resolves and follow your sources in dev.